### PR TITLE
Feature/sim 1150/redesign astrometry api

### DIFF
--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -129,17 +129,22 @@ def sphericalFromCartesian(xyz):
     """
     Transforms between Cartesian and spherical coordinates
 
-    @param [in] xyz is a list of the three-dimensional Cartesian coordinates
+    @param [in] xyz is a numpy array of points in 3-D space.
+    Each row is a different point.
 
     @param [out] returns longitude and latitude
 
     All angles are in radians
     """
 
-    rad = numpy.sqrt(xyz[:][0]*xyz[:][0] + xyz[:][1]*xyz[:][1] + xyz[:][2]*xyz[:][2])
-
-    longitude = numpy.arctan2( xyz[:][1], xyz[:][0])
-    latitude = numpy.arcsin( xyz[:][2] / rad)
+    if isinstance(xyz, numpy.ndarray) and len(xyz.shape)>1:
+        rad = numpy.sqrt(xyz[:,0]*xyz[:,0] + xyz[:,1]*xyz[:,1] + xyz[:,2]*xyz[:,2])
+        longitude = numpy.arctan2( xyz[:,1], xyz[:,0])
+        latitude = numpy.arcsin( xyz[:,2] / rad)
+    else:
+        rad = numpy.sqrt(numpy.dot(xyz,xyz))
+        longitude = numpy.arctan2(xyz[1], xyz[0])
+        latitude = numpy.arcsin(xyz[2]/rad)
 
     return longitude, latitude
 

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -176,11 +176,17 @@ def rotationMatrixFromVectors(v1, v2):
     '''
     Given two vectors v1,v2 calculate the rotation matrix for v1->v2 using the axis-angle approach
 
-    @param [in] v1, v2 are two Cartesian vectors (in three dimensions)
+    @param [in] v1, v2 are two Cartesian unit vectors (in three dimensions)
 
     @param [out] rot is the rotation matrix that rotates from one to the other
 
     '''
+
+    if numpy.abs(numpy.sqrt(numpy.dot(v1,v1))-1.0) > 0.01:
+        raise RuntimeError("v1 in rotationMatrixFromVectors is not a unit vector")
+
+    if numpy.abs(numpy.sqrt(numpy.dot(v2,v2))-1.0) > 0.01:
+        raise RuntimeError("v2 in rotationMatrixFromVectors is not a unit vector")
 
     # Calculate the axis of rotation by the cross product of v1 and v2
     cross = numpy.cross(v1,v2)

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -119,6 +119,9 @@ def cartesianFromSpherical(longitude, latitude):
     All angles are in radians
     """
 
+    if not isinstance(longitude, numpy.ndarray) or not isinstance(latitude, numpy.ndarray):
+        raise RuntimeError("you need to pass numpy arrays to cartesianFromSpherical")
+
     cosDec = numpy.cos(latitude)
     return numpy.array([numpy.cos(longitude)*cosDec,
                       numpy.sin(longitude)*cosDec,
@@ -137,7 +140,10 @@ def sphericalFromCartesian(xyz):
     All angles are in radians
     """
 
-    if isinstance(xyz, numpy.ndarray) and len(xyz.shape)>1:
+    if not isinstance(xyz, numpy.ndarray):
+        raise RuntimeError("you need to pass a numpy array to sphericalFromCartesian")
+
+    if len(xyz.shape)>1:
         rad = numpy.sqrt(numpy.power(xyz,2).sum(axis=1))
         longitude = numpy.arctan2( xyz[:,1], xyz[:,0])
         latitude = numpy.arcsin( xyz[:,2] / rad)

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -2,8 +2,7 @@ import numpy
 import palpy
 from collections import OrderedDict
 
-__all__ = ["horizontalFromEquatorial",
-           "galacticFromEquatorial", "equatorialFromGalactic",
+__all__ = ["galacticFromEquatorial", "equatorialFromGalactic",
            "sphericalFromCartesian", "cartesianFromSpherical",
            "rotationMatrixFromVectors",
            "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "altAzPaFromRaDec",
@@ -61,33 +60,6 @@ def calcLmstLast(mjd, longRad):
     lmst %= 24.
     last %= 24.
     return lmst, last
-
-
-def horizontalFromEquatorial(ra, dec, mjd, longitude, latitude):
-    """
-    Converts from equatorial to horizon coordinates
-
-    @param [in] ra is in radians
-
-    @param [in] dec is declination in radians
-
-    @param [in] mjd is the date
-
-    @param [in] longitude is the site longitude in radians
-    (positive to the east of the prime meridian)
-
-    @param [in] latitude is the site latitude in radians
-
-    @param [out] returns elevation angle and azimuth in that order (radians)
-
-    """
-
-    hourAngle = calcLmstLast(mjd, longitude)[1]*(2.0*numpy.pi/24.0) - ra
-
-    _de2hOutput=palpy.de2h(hourAngle, dec,  latitude)
-
-    #return (altitude, azimuth)
-    return _de2hOutput[1], _de2hOutput[0]
 
 
 def galacticFromEquatorial(ra, dec):

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -110,11 +110,11 @@ def cartesianFromSpherical(longitude, latitude):
     """
     Transforms between spherical and Cartesian coordinates.
 
-    @param [in] longitude is the input longitudinal coordinate
+    @param [in] longitude is a numpy array of longitudes
 
-    @param [in] latitude is the input latitudinal coordinate
+    @param [in] latitude is a numpy array of latitudes
 
-    @param [out] a list of the (three-dimensional) cartesian coordinates on a unit sphere
+    @param [out] a numpy array of the (three-dimensional) cartesian coordinates on a unit sphere
 
     All angles are in radians
     """
@@ -122,7 +122,7 @@ def cartesianFromSpherical(longitude, latitude):
     cosDec = numpy.cos(latitude)
     return numpy.array([numpy.cos(longitude)*cosDec,
                       numpy.sin(longitude)*cosDec,
-                      numpy.sin(latitude)])
+                      numpy.sin(latitude)]).transpose()
 
 
 def sphericalFromCartesian(xyz):

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -2,11 +2,57 @@ import numpy
 import palpy
 from collections import OrderedDict
 
-__all__ = ["equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "raDecToAltAzPa",
+__all__ = ["equatorialToGalactic", "galacticToEquatorial",
+           "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "raDecToAltAzPa",
            "altAzToRaDec", "getRotSkyPos", "getRotTelPos", "haversine",
            "calcObsDefaults", "makeObservationMetadata", "makeObsParamsAzAltTel",
            "makeObsParamsAzAltSky", "makeObsParamsRaDecTel", "makeObsParamsRaDecSky",
            "radiansToArcsec","arcsecToRadians"]
+
+
+
+def equatorialToGalactic(ra, dec):
+    '''Convert RA,Dec (J2000) to Galactic Coordinates
+
+    All angles are in radians
+
+    @param [in] ra is right ascension in radians, either a float or a numpy array
+
+    @param [in] dec is declination in radians, either a float or a numpy array
+
+    @param [out] gLong is galactic longitude in radians
+
+    @param [out] gLat is galactic latitude in radians
+    '''
+
+    if isinstance(ra, numpy.ndarray):
+        gLong, gLat = palpy.eqgalVector(ra, dec)
+    else:
+        gLong, gLat = palpy.eqgal(ra, dec)
+
+    return gLong, gLat
+
+
+def galacticToEquatorial(gLong, gLat):
+    '''Convert Galactic Coordinates to RA, dec (J2000)
+
+    @param [in] gLong is galactic longitude in radians, either a float or a numpy array
+
+    @param [in] gLat is galactic latitude in radians, either a float or a numpy array
+
+    @param [out] ra is right ascension in radians
+
+    @param [out] dec is declination in radians
+    '''
+
+    if isinstance(gLong, numpy.ndarray):
+        ra, dec = palpy.galeqVector(gLong, gLat)
+    else:
+        ra, dec = palpy.galeq(gLong, gLat)
+
+    return ra, dec
+
+
 
 def equationOfEquinoxes(d):
     """

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -277,10 +277,10 @@ def altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd):
     """
 
     if isinstance(longRad, numpy.ndarray):
-        raise RuntimeError('cannot pass numpy array of longitudes to raDecToAltAzPa')
+        raise RuntimeError('cannot pass numpy array of longitudes to altAzPaFromRaDec')
 
     if isinstance(latRad, numpy.ndarray):
-        raise RuntimeError('cannot pass numpy array of latitudes to raDecToAltAzPa')
+        raise RuntimeError('cannot pass numpy array of latitudes to altAzPaFromRaDec')
 
     raIsArray = False
     decIsArray = False
@@ -295,19 +295,19 @@ def altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd):
         mjdIsArray = True
 
     if raIsArray and not decIsArray:
-        raise RuntimeError('passed numpy array of RA to raDecToAltAzPa; but only one Dec')
+        raise RuntimeError('passed numpy array of RA to altAzPaFromRaDec; but only one Dec')
 
     if decIsArray and not raIsArray:
-        raise RuntimeError('passed numpy array of Dec to raDecToAltAzPa; but only one RA')
+        raise RuntimeError('passed numpy array of Dec to altAzPaFromRaDec; but only one RA')
 
     if raIsArray and decIsArray and len(raRad) != len(decRad):
-        raise RuntimeError('in raDecToAltAzPa length of RA numpy array does not match length of Dec numpy array')
+        raise RuntimeError('in altAzPaFromRaDec length of RA numpy array does not match length of Dec numpy array')
 
     if mjdIsArray and not raIsArray:
-        raise RuntimeError('passed numpy array of mjd to raDecToAltAzPa; but only one RA, Dec')
+        raise RuntimeError('passed numpy array of mjd to altAzPaFromRaDec; but only one RA, Dec')
 
     if mjdIsArray and len(mjd) != len(raRad):
-        raise RuntimeError('in raDecToAltAzPa length of mjd numpy array is not the same as length of RA numpy array')
+        raise RuntimeError('in altAzPaFromRaDec length of mjd numpy array is not the same as length of RA numpy array')
 
     lst = calcLmstLast(mjd, longRad)
     last = lst[1]
@@ -348,10 +348,10 @@ def raDecFromAltAz(altRad, azRad, longRad, latRad, mjd):
     @param [out] Dec in radians
     """
     if isinstance(longRad, numpy.ndarray):
-        raise RuntimeError('cannot pass a numpy array of longitudes to altAzToRaDec')
+        raise RuntimeError('cannot pass a numpy array of longitudes to raDecFromAltAz')
 
     if isinstance(latRad, numpy.ndarray):
-        raise RuntimeError('cannot pass a numpy array of latitudes to altAzToRaDec')
+        raise RuntimeError('cannot pass a numpy array of latitudes to raDecFromAltAz')
 
     mjdIsArray = False
     altIsArray = False
@@ -366,19 +366,19 @@ def raDecFromAltAz(altRad, azRad, longRad, latRad, mjd):
         azIsArray = True
 
     if altIsArray and not azIsArray:
-        raise RuntimeError('passed a numpy array of alt to altAzToRaDec, but only one az')
+        raise RuntimeError('passed a numpy array of alt to raDecFromAltAz, but only one az')
 
     if azIsArray and not altIsArray:
-        raise RuntimeError('passed a numpy array of az to altAzToRaDec, but only one alt')
+        raise RuntimeError('passed a numpy array of az to raDecFromAltAz, but only one alt')
 
     if azIsArray and altIsArray and len(altRad)!=len(azRad):
-        raise RuntimeError('in altAzToRaDec, length of alt numpy array does not match length of az numpy array')
+        raise RuntimeError('in raDecFromAltAz, length of alt numpy array does not match length of az numpy array')
 
     if mjdIsArray and not azIsArray:
-        raise RuntimeError('passed a numpy array of mjd to altAzToRaDec, but only one alt, az pair')
+        raise RuntimeError('passed a numpy array of mjd to raDecFromAltAz, but only one alt, az pair')
 
     if mjdIsArray and len(mjd) != len(azRad):
-        raise RuntimeError('in altAzToRaDec length of mjd numpy array does not match length of az numpy array')
+        raise RuntimeError('in raDecFromAltAz length of mjd numpy array does not match length of az numpy array')
 
     lst = calcLmstLast(mjd, longRad)
     last = lst[1]
@@ -418,7 +418,7 @@ def getRotSkyPos(raRad, decRad, longRad, latRad, mjd, rotTelRad):
     WARNING: As of 13 April 2015, this method does not agree with OpSim on
     the relationship between rotSkyPos and rotTelPos
     """
-    altRad, azRad, paRad = raDecToAltAzPa(raRad, decRad, longRad, latRad, mjd)
+    altRad, azRad, paRad = altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd)
 
     #20 March 2015
     #I do not know where this expression comes from; we should validate it against
@@ -453,7 +453,7 @@ def getRotTelPos(raRad, decRad, longRad, latRad, mjd, rotSkyRad):
     WARNING: as of 13 April 2015, this method does not agree with OpSim on
     the relationship between rotSkyPos and rotTelPos
     """
-    altRad, azRad, paRad = raDecToAltAzPa(raRad, decRad, longRad, latRad, mjd)
+    altRad, azRad, paRad = altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd)
 
     #20 March 2015
     #I do not know where this expression comes from; we should validate it against
@@ -518,7 +518,7 @@ def calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad,
     """
     obsMd = {}
     #Defaults
-    moonra, moondec = altAzToRaDec(-numpy.pi/2., 0., longRad, latRad, mjd)
+    moonra, moondec = raDecFromAltAz(-numpy.pi/2., 0., longRad, latRad, mjd)
     sunalt = -numpy.pi/2.
     moonalt = -numpy.pi/2.
     dist2moon = haversine(moonra, moondec, raRad, decRad)
@@ -555,7 +555,7 @@ def makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=0., longRad=-1.232
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
 
-    raRad, decRad = altAzToRaDec(altRad, azRad, longRad, latRad, mjd)
+    raRad, decRad = raDecFromAltAz(altRad, azRad, longRad, latRad, mjd)
     obsMd = calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad, latRad)
     obsMd.update(kwargs)
     return makeObservationMetadata(obsMd)
@@ -572,7 +572,7 @@ def makeObsParamsAzAltSky(azRad, altRad, mjd, band, rotSkyRad=numpy.pi, longRad=
     latRad -- Latitude of the observatory in radians Default=-0.517781017
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
-    raRad, decRad = altAzToRaDec(altRad, azRad, longRad, latRad, mjd)
+    raRad, decRad = raDecFromAltAz(altRad, azRad, longRad, latRad, mjd)
     rotTelRad = getRotTelPos(raRad, decRad, longRad, latRad, mjd, rotSkyRad)
     return makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=rotTelRad, longRad=longRad, latRad=latRad, **kwargs)
 
@@ -589,7 +589,7 @@ def makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=0., longRad=-1.232
     latRad -- Latitude of the observatory in radians Default=-0.517781017
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
-    altRad, azRad, paRad = raDecToAltAzPa(raRad, decRad, longRad, latRad, mjd)
+    altRad, azRad, paRad = altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd)
     obsMd = calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad, latRad)
     obsMd.update(kwargs)
     return makeObservationMetadata(obsMd)

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -138,7 +138,7 @@ def sphericalFromCartesian(xyz):
     """
 
     if isinstance(xyz, numpy.ndarray) and len(xyz.shape)>1:
-        rad = numpy.sqrt(xyz[:,0]*xyz[:,0] + xyz[:,1]*xyz[:,1] + xyz[:,2]*xyz[:,2])
+        rad = numpy.sqrt(numpy.power(xyz,2).sum(axis=1))
         longitude = numpy.arctan2( xyz[:,1], xyz[:,0])
         latitude = numpy.arcsin( xyz[:,2] / rad)
     else:

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 __all__ = ["equatorialToGalactic", "galacticToEquatorial",
            "cartesianToSpherical", "sphericalToCartesian",
+           "rotationMatrixFromVectors",
            "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "raDecToAltAzPa",
            "altAzToRaDec", "getRotSkyPos", "getRotTelPos", "haversine",
            "calcObsDefaults", "makeObservationMetadata", "makeObsParamsAzAltTel",
@@ -90,6 +91,38 @@ def cartesianToSpherical(xyz):
     latitude = numpy.arcsin( xyz[:][2] / rad)
 
     return longitude, latitude
+
+
+def rotationMatrixFromVectors(v1, v2):
+    '''
+    Given two vectors v1,v2 calculate the rotation matrix for v1->v2 using the axis-angle approach
+
+    @param [in] v1, v2 are two Cartesian vectors (in three dimensions)
+
+    @param [out] rot is the rotation matrix that rotates from one to the other
+
+    '''
+
+    # Calculate the axis of rotation by the cross product of v1 and v2
+    cross = numpy.cross(v1,v2)
+    cross = cross / numpy.sqrt(numpy.dot(cross,cross))
+
+    # calculate the angle of rotation via dot product
+    angle  = numpy.arccos(numpy.dot(v1,v2))
+    sinDot = numpy.sin(angle)
+    cosDot = numpy.cos(angle)
+
+    # calculate the corresponding rotation matrix
+    # http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle
+    rot = [[cosDot + cross[0]*cross[0]*(1-cosDot), -cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1], \
+            cross[1]*sinDot + (1-cosDot)*cross[0]*cross[2]],\
+            [cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1], cosDot + (1-cosDot)*cross[1]*cross[1], \
+            -cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2]], \
+            [-cross[1]*sinDot+(1-cosDot)*cross[0]*cross[2], \
+            cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2], \
+            cosDot + (1-cosDot)*(cross[2]*cross[2])]]
+
+    return rot
 
 
 def equationOfEquinoxes(d):

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -3,6 +3,7 @@ import palpy
 from collections import OrderedDict
 
 __all__ = ["equatorialToGalactic", "galacticToEquatorial",
+           "cartesianToSpherical", "sphericalToCartesian",
            "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "raDecToAltAzPa",
            "altAzToRaDec", "getRotSkyPos", "getRotTelPos", "haversine",
            "calcObsDefaults", "makeObservationMetadata", "makeObsParamsAzAltTel",
@@ -52,6 +53,43 @@ def galacticToEquatorial(gLong, gLat):
 
     return ra, dec
 
+
+def sphericalToCartesian(longitude, latitude):
+    """
+    Transforms between spherical and Cartesian coordinates.
+
+    @param [in] longitude is the input longitudinal coordinate
+
+    @param [in] latitude is the input latitudinal coordinate
+
+    @param [out] a list of the (three-dimensional) cartesian coordinates on a unit sphere
+
+    All angles are in radians
+    """
+
+    cosDec = numpy.cos(latitude)
+    return numpy.array([numpy.cos(longitude)*cosDec,
+                      numpy.sin(longitude)*cosDec,
+                      numpy.sin(latitude)])
+
+
+def cartesianToSpherical(xyz):
+    """
+    Transforms between Cartesian and spherical coordinates
+
+    @param [in] xyz is a list of the three-dimensional Cartesian coordinates
+
+    @param [out] returns longitude and latitude
+
+    All angles are in radians
+    """
+
+    rad = numpy.sqrt(xyz[:][0]*xyz[:][0] + xyz[:][1]*xyz[:][1] + xyz[:][2]*xyz[:][2])
+
+    longitude = numpy.arctan2( xyz[:][1], xyz[:][0])
+    latitude = numpy.arcsin( xyz[:][2] / rad)
+
+    return longitude, latitude
 
 
 def equationOfEquinoxes(d):

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -116,8 +116,10 @@ def equatorialFromGalactic(gLong, gLat):
     '''Convert Galactic Coordinates to RA, dec (J2000)
 
     @param [in] gLong is galactic longitude in radians, either a float or a numpy array
+    (0 <= gLong <= 2*pi)
 
     @param [in] gLat is galactic latitude in radians, either a float or a numpy array
+    (-pi/2 <= gLat <= pi/2)
 
     @param [out] ra is right ascension in radians
 

--- a/python/lsst/sims/utils/coordinateTransformations.py
+++ b/python/lsst/sims/utils/coordinateTransformations.py
@@ -2,15 +2,15 @@ import numpy
 import palpy
 from collections import OrderedDict
 
-__all__ = ["equatorialToHorizontal",
-           "equatorialToGalactic", "galacticToEquatorial",
-           "cartesianToSpherical", "sphericalToCartesian",
+__all__ = ["horizontalFromEquatorial",
+           "galacticFromEquatorial", "equatorialFromGalactic",
+           "sphericalFromCartesian", "cartesianFromSpherical",
            "rotationMatrixFromVectors",
-           "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "raDecToAltAzPa",
-           "altAzToRaDec", "getRotSkyPos", "getRotTelPos", "haversine",
+           "equationOfEquinoxes", "calcGmstGast", "calcLmstLast", "altAzPaFromRaDec",
+           "raDecFromAltAz", "getRotSkyPos", "getRotTelPos", "haversine",
            "calcObsDefaults", "makeObservationMetadata", "makeObsParamsAzAltTel",
            "makeObsParamsAzAltSky", "makeObsParamsRaDecTel", "makeObsParamsRaDecSky",
-           "radiansToArcsec","arcsecToRadians"]
+           "arcsecFromRadians","radiansFromArcsec"]
 
 
 def calcLmstLast(mjd, longRad):
@@ -63,7 +63,7 @@ def calcLmstLast(mjd, longRad):
     return lmst, last
 
 
-def equatorialToHorizontal(ra, dec, mjd, longitude, latitude):
+def horizontalFromEquatorial(ra, dec, mjd, longitude, latitude):
     """
     Converts from equatorial to horizon coordinates
 
@@ -90,7 +90,7 @@ def equatorialToHorizontal(ra, dec, mjd, longitude, latitude):
     return _de2hOutput[1], _de2hOutput[0]
 
 
-def equatorialToGalactic(ra, dec):
+def galacticFromEquatorial(ra, dec):
     '''Convert RA,Dec (J2000) to Galactic Coordinates
 
     All angles are in radians
@@ -112,7 +112,7 @@ def equatorialToGalactic(ra, dec):
     return gLong, gLat
 
 
-def galacticToEquatorial(gLong, gLat):
+def equatorialFromGalactic(gLong, gLat):
     '''Convert Galactic Coordinates to RA, dec (J2000)
 
     @param [in] gLong is galactic longitude in radians, either a float or a numpy array
@@ -132,7 +132,7 @@ def galacticToEquatorial(gLong, gLat):
     return ra, dec
 
 
-def sphericalToCartesian(longitude, latitude):
+def cartesianFromSpherical(longitude, latitude):
     """
     Transforms between spherical and Cartesian coordinates.
 
@@ -151,7 +151,7 @@ def sphericalToCartesian(longitude, latitude):
                       numpy.sin(latitude)])
 
 
-def cartesianToSpherical(xyz):
+def sphericalFromCartesian(xyz):
     """
     Transforms between Cartesian and spherical coordinates
 
@@ -249,7 +249,7 @@ def calcGmstGast(mjd):
     return gmst, gast
 
 
-def raDecToAltAzPa(raRad, decRad, longRad, latRad, mjd):
+def altAzPaFromRaDec(raRad, decRad, longRad, latRad, mjd):
     """
     Convert RA, Dec, longitude, latitude and MJD into altitude, azimuth
     and parallactic angle using PALPY
@@ -324,7 +324,7 @@ def raDecToAltAzPa(raRad, decRad, longRad, latRad, mjd):
 
     return alt, az, pa
 
-def altAzToRaDec(altRad, azRad, longRad, latRad, mjd):
+def raDecFromAltAz(altRad, azRad, longRad, latRad, mjd):
     """
     Convert altitude and azimuth to RA and Dec
 
@@ -609,14 +609,14 @@ def makeObsParamsRaDecSky(raRad, decRad, mjd, band, rotSkyRad=numpy.pi, longRad=
     rotTelRad = getRotTelPos(raRad, decRad, longRad, latRad, mjd, rotSkyRad)
     return makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=rotTelRad, longRad=longRad, latRad=latRad, **kwargs)
 
-def radiansToArcsec(value):
+def arcsecFromRadians(value):
     """
     Convert an angle in radians to arcseconds
     """
 
     return 3600.0*numpy.degrees(value)
 
-def arcsecToRadians(value):
+def radiansFromArcsec(value):
     """
     Convert an angle in arcseconds to radians
     """

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -4,6 +4,7 @@ import unittest
 import palpy as palpy
 import lsst.utils.tests as utilsTests
 import lsst.sims.utils as utils
+from lsst.sims.utils import Site
 
 def controlRaDecToAltAz(raRad, decRad, longRad, latRad, mjd):
     """
@@ -390,6 +391,17 @@ class testCoordinateTransformations(unittest.TestCase):
 
         for i in range(3):
             self.assertAlmostEqual(v3[i],v2[i],7)
+
+
+    def testEquatorialToHorizontal(self):
+        arg1=2.549091039839124218e+00
+        arg2=5.198752733024248895e-01
+        arg3=2.004031374869656474e+03
+        output=utils.equatorialToHorizontal(arg1,arg2,arg3,
+        longitude=Site().longitude,latitude=Site().latitude)
+
+        self.assertAlmostEqual(output[0],4.486633480937949336e-01,4)
+        self.assertAlmostEqual(output[1],5.852620488358430961e+00,4)
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -358,6 +358,16 @@ class testCoordinateTransformations(unittest.TestCase):
                 self.assertAlmostEqual(vv[j],xyz[j][i],7)
 
 
+    def testHaversine(self):
+        arg1 = 7.853981633974482790e-01
+        arg2 = 3.769911184307751517e-01
+        arg3 = 5.026548245743668986e+00
+        arg4 = -6.283185307179586232e-01
+
+        output=utils.haversine(arg1,arg2,arg3,arg4)
+
+        self.assertAlmostEqual(output,2.162615946398791955e+00,10)
+
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -309,6 +309,55 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertAlmostEqual(output[1][2],2.758053025017753179e-01,6)
 
 
+    def testSphericalToCartesian(self):
+        arg1=2.19911485751
+        arg2=5.96902604182
+        output=utils.sphericalToCartesian(arg1,arg2)
+
+        vv=numpy.zeros((3),dtype=float)
+        vv[0]=numpy.cos(arg2)*numpy.cos(arg1)
+        vv[1]=numpy.cos(arg2)*numpy.sin(arg1)
+        vv[2]=numpy.sin(arg2)
+
+        self.assertAlmostEqual(output[0],vv[0],7)
+        self.assertAlmostEqual(output[1],vv[1],7)
+        self.assertAlmostEqual(output[2],vv[2],7)
+
+
+    def testCartesianToSpherical(self):
+        """
+        Note that xyz[i][j] is the ith component of the jth vector
+
+        Each column of xyz is a vector
+        """
+        xyz=numpy.zeros((3,3),dtype=float)
+
+        xyz[0][0]=-1.528397655830016078e-03
+        xyz[0][1]=-1.220314328441649110e+00
+        xyz[0][2]=-1.209496845057127512e+00
+        xyz[1][0]=-2.015391452804179195e+00
+        xyz[1][1]=3.209255728096233051e-01
+        xyz[1][2]=-2.420049632697228503e+00
+        xyz[2][0]=-1.737023855580406284e+00
+        xyz[2][1]=-9.876134719050078115e-02
+        xyz[2][2]=-2.000636201137401038e+00
+
+        output=utils.cartesianToSpherical(xyz)
+
+        vv=numpy.zeros((3),dtype=float)
+
+        for i in range(3):
+
+            rr=numpy.sqrt(xyz[0][i]*xyz[0][i]+xyz[1][i]*xyz[1][i]+xyz[2][i]*xyz[2][i])
+
+            vv[0]=rr*numpy.cos(output[1][i])*numpy.cos(output[0][i])
+            vv[1]=rr*numpy.cos(output[1][i])*numpy.sin(output[0][i])
+            vv[2]=rr*numpy.sin(output[1][i])
+
+            for j in range(3):
+                self.assertAlmostEqual(vv[j],xyz[j][i],7)
+
+
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -266,6 +266,48 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertTrue(numpy.abs(numpy.cos(decOut) - numpy.cos(d)) < self.tolerance)
             self.assertTrue(numpy.abs(numpy.sin(decOut) - numpy.sin(d)) < self.tolerance)
 
+    def testEquatorialToGalactic(self):
+
+        ra=numpy.zeros((3),dtype=float)
+        dec=numpy.zeros((3),dtype=float)
+
+        ra[0]=2.549091039839124218e+00
+        dec[0]=5.198752733024248895e-01
+        ra[1]=8.693375673649429425e-01
+        dec[1]=1.038086165642298164e+00
+        ra[2]=7.740864769302191473e-01
+        dec[2]=2.758053025017753179e-01
+
+        output=utils.equatorialToGalactic(ra,dec)
+
+        self.assertAlmostEqual(output[0][0],3.452036693523627964e+00,6)
+        self.assertAlmostEqual(output[1][0],8.559512505657201897e-01,6)
+        self.assertAlmostEqual(output[0][1],2.455968474619387720e+00,6)
+        self.assertAlmostEqual(output[1][1],3.158563770667878468e-02,6)
+        self.assertAlmostEqual(output[0][2],2.829585540991265358e+00,6)
+        self.assertAlmostEqual(output[1][2],-6.510790587552289788e-01,6)
+
+    def testGalacticToEquatorial(self):
+
+        lon=numpy.zeros((3),dtype=float)
+        lat=numpy.zeros((3),dtype=float)
+
+        lon[0]=3.452036693523627964e+00
+        lat[0]=8.559512505657201897e-01
+        lon[1]=2.455968474619387720e+00
+        lat[1]=3.158563770667878468e-02
+        lon[2]=2.829585540991265358e+00
+        lat[2]=-6.510790587552289788e-01
+
+        output=utils.galacticToEquatorial(lon,lat)
+
+        self.assertAlmostEqual(output[0][0],2.549091039839124218e+00,6)
+        self.assertAlmostEqual(output[1][0],5.198752733024248895e-01,6)
+        self.assertAlmostEqual(output[0][1],8.693375673649429425e-01,6)
+        self.assertAlmostEqual(output[1][1],1.038086165642298164e+00,6)
+        self.assertAlmostEqual(output[0][2],7.740864769302191473e-01,6)
+        self.assertAlmostEqual(output[1][2],2.758053025017753179e-01,6)
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -392,6 +392,10 @@ class testCoordinateTransformations(unittest.TestCase):
         for i in range(3):
             self.assertAlmostEqual(v3[i],v2[i],7)
 
+        v1 = numpy.array([1.0, 1.0, 1.0])
+        self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v1, v2)
+        self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v2, v1)
+
 
     def testHorizontalFromEquatorial(self):
         arg1=2.549091039839124218e+00

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -331,32 +331,34 @@ class testCoordinateTransformations(unittest.TestCase):
 
         Each column of xyz is a vector
         """
-        xyz=numpy.zeros((3,3),dtype=float)
+        numpy.random.seed(42)
+        nsamples = 10
+        radius = numpy.random.random_sample(nsamples)*10.0
+        theta = numpy.random.random_sample(nsamples)*numpy.pi-0.5*numpy.pi
+        phi = numpy.random.random_sample(nsamples)*2.0*numpy.pi
 
-        xyz[0][0]=-1.528397655830016078e-03
-        xyz[0][1]=-1.220314328441649110e+00
-        xyz[0][2]=-1.209496845057127512e+00
-        xyz[1][0]=-2.015391452804179195e+00
-        xyz[1][1]=3.209255728096233051e-01
-        xyz[1][2]=-2.420049632697228503e+00
-        xyz[2][0]=-1.737023855580406284e+00
-        xyz[2][1]=-9.876134719050078115e-02
-        xyz[2][2]=-2.000636201137401038e+00
+        points = []
+        for ix in range(nsamples):
+            vv = [radius[ix]*numpy.cos(theta[ix])*numpy.cos(phi[ix]),
+                  radius[ix]*numpy.cos(theta[ix])*numpy.sin(phi[ix]),
+                  radius[ix]*numpy.sin(theta[ix])]
 
-        output=utils.sphericalFromCartesian(xyz)
+            points.append(vv)
 
-        vv=numpy.zeros((3),dtype=float)
+        points = numpy.array(points)
+        lon, lat = utils.sphericalFromCartesian(points)
+        for ix in range(nsamples):
+            self.assertAlmostEqual(numpy.cos(lon[ix]), numpy.cos(phi[ix]), 5)
+            self.assertAlmostEqual(numpy.sin(lon[ix]), numpy.sin(phi[ix]), 5)
+            self.assertAlmostEqual(numpy.cos(lat[ix]), numpy.cos(theta[ix]), 5)
+            self.assertAlmostEqual(numpy.sin(lat[ix]), numpy.sin(theta[ix]), 5)
 
-        for i in range(3):
-
-            rr=numpy.sqrt(xyz[0][i]*xyz[0][i]+xyz[1][i]*xyz[1][i]+xyz[2][i]*xyz[2][i])
-
-            vv[0]=rr*numpy.cos(output[1][i])*numpy.cos(output[0][i])
-            vv[1]=rr*numpy.cos(output[1][i])*numpy.sin(output[0][i])
-            vv[2]=rr*numpy.sin(output[1][i])
-
-            for j in range(3):
-                self.assertAlmostEqual(vv[j],xyz[j][i],7)
+        for pp, th, ph in zip(points, theta, phi):
+            lon, lat = utils.sphericalFromCartesian(list(pp))
+            self.assertAlmostEqual(numpy.cos(lon), numpy.cos(ph), 5)
+            self.assertAlmostEqual(numpy.sin(lon), numpy.sin(ph), 5)
+            self.assertAlmostEqual(numpy.cos(lat), numpy.cos(th), 5)
+            self.assertAlmostEqual(numpy.sin(lat), numpy.sin(th), 5)
 
 
     def testHaversine(self):

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -368,6 +368,29 @@ class testCoordinateTransformations(unittest.TestCase):
 
         self.assertAlmostEqual(output,2.162615946398791955e+00,10)
 
+
+
+    def testRotationMatrixFromVectors(self):
+        v1=numpy.zeros((3),dtype=float)
+        v2=numpy.zeros((3),dtype=float)
+        v3=numpy.zeros((3),dtype=float)
+
+        v1[0]=-3.044619987218469825e-01
+        v2[0]=5.982190522311925385e-01
+        v1[1]=-5.473550908956383854e-01
+        v2[1]=-5.573565912346714057e-01
+        v1[2]=7.795545496018386755e-01
+        v2[2]=-5.757495946632366079e-01
+
+        output=utils.rotationMatrixFromVectors(v1,v2)
+
+        for i in range(3):
+            for j in range(3):
+                v3[i]+=output[i][j]*v1[j]
+
+        for i in range(3):
+            self.assertAlmostEqual(v3[i],v2[i],7)
+
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -354,12 +354,34 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(numpy.sin(lat[ix]), numpy.sin(theta[ix]), 5)
 
         for pp, th, ph in zip(points, theta, phi):
-            lon, lat = utils.sphericalFromCartesian(list(pp))
+            lon, lat = utils.sphericalFromCartesian(pp)
             self.assertAlmostEqual(numpy.cos(lon), numpy.cos(ph), 5)
             self.assertAlmostEqual(numpy.sin(lon), numpy.sin(ph), 5)
             self.assertAlmostEqual(numpy.cos(lat), numpy.cos(th), 5)
             self.assertAlmostEqual(numpy.sin(lat), numpy.sin(th), 5)
 
+
+    def testCartesianFromSpherical(self):
+        numpy.random.seed(42)
+        nsamples = 10
+        theta = numpy.random.random_sample(nsamples)*numpy.pi-0.5*numpy.pi
+        phi = numpy.random.random_sample(nsamples)*2.0*numpy.pi
+
+        points = []
+        for ix in range(nsamples):
+            vv = [numpy.cos(theta[ix])*numpy.cos(phi[ix]),
+                  numpy.cos(theta[ix])*numpy.sin(phi[ix]),
+                  numpy.sin(theta[ix])]
+
+            points.append(vv)
+
+
+        points = numpy.array(points)
+        lon, lat = utils.sphericalFromCartesian(points)
+        outPoints = utils.cartesianFromSpherical(numpy.array(lon), numpy.array(lat))
+
+        for pp, oo in zip(points, outPoints):
+            numpy.testing.assert_array_almost_equal(pp, oo, decimal=6)
 
     def testHaversine(self):
         arg1 = 7.853981633974482790e-01

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -6,7 +6,7 @@ import lsst.utils.tests as utilsTests
 import lsst.sims.utils as utils
 from lsst.sims.utils import Site
 
-def controlRaDecToAltAz(raRad, decRad, longRad, latRad, mjd):
+def controlAltAzFromRaDec(raRad, decRad, longRad, latRad, mjd):
     """
     Converts RA and Dec to altitude and azimuth
 
@@ -107,25 +107,25 @@ class testCoordinateTransformations(unittest.TestCase):
         ans = utils.calcLmstLast(mjdFloat, longFloat)
         ans = utils.calcLmstLast(mjd2, longList)
 
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raList, decList, longList, latFloat, mjd2)
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raList, decList, longFloat, latList, mjd2)
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raList, decFloat, longFloat, latFloat, mjdFloat)
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raFloat, decList, longFloat, latFloat, mjdFloat)
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raFloat, decFloat, longFloat, latFloat, mjd2)
-        self.assertRaises(RuntimeError, utils.raDecToAltAzPa, raList, decList, longFloat, latFloat, mjd3)
-        ans = utils.raDecToAltAzPa(raFloat, decFloat, longFloat, latFloat, mjdFloat)
-        ans = utils.raDecToAltAzPa(raList, decList, longFloat, latFloat, mjdFloat)
-        ans = utils.raDecToAltAzPa(raList, decList, longFloat, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raList, decList, longList, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raList, decList, longFloat, latList, mjd2)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raList, decFloat, longFloat, latFloat, mjdFloat)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raFloat, decList, longFloat, latFloat, mjdFloat)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raFloat, decFloat, longFloat, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raList, decList, longFloat, latFloat, mjd3)
+        ans = utils.altAzPaFromRaDec(raFloat, decFloat, longFloat, latFloat, mjdFloat)
+        ans = utils.altAzPaFromRaDec(raList, decList, longFloat, latFloat, mjdFloat)
+        ans = utils.altAzPaFromRaDec(raList, decList, longFloat, latFloat, mjd2)
 
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raList, decList, longList, latFloat, mjd2)
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raList, decList, longFloat, latList, mjd2)
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raList, decFloat, longFloat, latFloat, mjdFloat)
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raFloat, decList, longFloat, latFloat, mjdFloat)
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raFloat, decFloat, longFloat, latFloat, mjd2)
-        self.assertRaises(RuntimeError, utils.altAzToRaDec, raList, decList, longFloat, latFloat, mjd3)
-        ans = utils.altAzToRaDec(raFloat, decFloat, longFloat, latFloat, mjdFloat)
-        ans = utils.altAzToRaDec(raList, decList, longFloat, latFloat, mjdFloat)
-        ans = utils.altAzToRaDec(raList, decList, longFloat, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raList, decList, longList, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raList, decList, longFloat, latList, mjd2)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raList, decFloat, longFloat, latFloat, mjdFloat)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raFloat, decList, longFloat, latFloat, mjdFloat)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raFloat, decFloat, longFloat, latFloat, mjd2)
+        self.assertRaises(RuntimeError, utils.raDecFromAltAz, raList, decList, longFloat, latFloat, mjd3)
+        ans = utils.raDecFromAltAz(raFloat, decFloat, longFloat, latFloat, mjdFloat)
+        ans = utils.raDecFromAltAz(raList, decList, longFloat, latFloat, mjdFloat)
+        ans = utils.raDecFromAltAz(raList, decList, longFloat, latFloat, mjd2)
 
 
     def testEquationOfEquinoxes(self):
@@ -196,7 +196,7 @@ class testCoordinateTransformations(unittest.TestCase):
                 self.assertTrue(numpy.abs(testLast - controlLast) < self.tolerance)
 
 
-    def testRaDecToAltAz(self):
+    def testAltAzFromRaDec(self):
         """
         Test conversion from RA, Dec to Alt, Az
         """
@@ -206,7 +206,7 @@ class testCoordinateTransformations(unittest.TestCase):
         dec = (numpy.random.sample(len(self.mjd))-0.5)*numpy.pi
         longitude = 1.467
         latitude = -0.234
-        controlAlt, controlAz = controlRaDecToAltAz(ra, dec, \
+        controlAlt, controlAz = controlAltAzFromRaDec(ra, dec, \
                                                     longitude, latitude, \
                                                     self. mjd)
 
@@ -217,7 +217,7 @@ class testCoordinateTransformations(unittest.TestCase):
         hourAngle = numpy.radians(last*15.0) - ra
         controlSinPa = numpy.sin(hourAngle)*numpy.cos(latitude)/numpy.cos(controlAlt)
 
-        testAlt, testAz, testPa = utils.raDecToAltAzPa(ra, dec, \
+        testAlt, testAz, testPa = utils.altAzPaFromRaDec(ra, dec, \
                                                        longitude, latitude, \
                                                        self.mjd)
 
@@ -227,8 +227,8 @@ class testCoordinateTransformations(unittest.TestCase):
 
         #test non-vectorized version
         for r,d,m in zip(ra, dec, self.mjd):
-            controlAlt, controlAz = controlRaDecToAltAz(r, d, longitude, latitude, m)
-            testAlt, testAz, testPa = utils.raDecToAltAzPa(r, d, longitude, latitude, m)
+            controlAlt, controlAz = controlAltAzFromRaDec(r, d, longitude, latitude, m)
+            testAlt, testAz, testPa = utils.altAzPaFromRaDec(r, d, longitude, latitude, m)
             lmst, last = utils.calcLmstLast(m, longitude)
             hourAngle = numpy.radians(last*15.0) - r
             controlSinPa = numpy.sin(hourAngle)*numpy.cos(latitude)/numpy.cos(controlAlt)
@@ -236,7 +236,7 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertTrue(numpy.abs(testAlt - controlAlt) < self.tolerance)
             self.assertTrue(numpy.abs(numpy.sin(testPa) - controlSinPa) < self.tolerance)
 
-    def testAltAzToRaDec(self):
+    def testRaDecFromAltAz(self):
         """
         Test conversion of Alt, Az t Ra, Dec
         """
@@ -251,7 +251,7 @@ class testCoordinateTransformations(unittest.TestCase):
         controlAlt, eld, eldd, \
         pa, pad, padd = palpy.altazVector(hourAngle, decIn, latitude)
 
-        raOut, decOut, = utils.altAzToRaDec(controlAlt, controlAz,
+        raOut, decOut, = utils.raDecFromAltAz(controlAlt, controlAz,
                                            longitude, latitude, self.mjd)
 
         self.assertTrue(numpy.abs(numpy.cos(raOut) - numpy.cos(raIn)).max() < self.tolerance)
@@ -261,13 +261,13 @@ class testCoordinateTransformations(unittest.TestCase):
 
         #test non-vectorized version
         for alt, az, r, d, m in zip(controlAlt, controlAz, raIn, decIn, self.mjd):
-            raOut, decOut = utils.altAzToRaDec(alt, az, longitude, latitude, m)
+            raOut, decOut = utils.raDecFromAltAz(alt, az, longitude, latitude, m)
             self.assertTrue(numpy.abs(numpy.cos(raOut) - numpy.cos(r)) < self.tolerance)
             self.assertTrue(numpy.abs(numpy.sin(raOut) - numpy.sin(r)) < self.tolerance)
             self.assertTrue(numpy.abs(numpy.cos(decOut) - numpy.cos(d)) < self.tolerance)
             self.assertTrue(numpy.abs(numpy.sin(decOut) - numpy.sin(d)) < self.tolerance)
 
-    def testEquatorialToGalactic(self):
+    def testGalacticFromEquatorial(self):
 
         ra=numpy.zeros((3),dtype=float)
         dec=numpy.zeros((3),dtype=float)
@@ -279,7 +279,7 @@ class testCoordinateTransformations(unittest.TestCase):
         ra[2]=7.740864769302191473e-01
         dec[2]=2.758053025017753179e-01
 
-        output=utils.equatorialToGalactic(ra,dec)
+        output=utils.galacticFromEquatorial(ra,dec)
 
         self.assertAlmostEqual(output[0][0],3.452036693523627964e+00,6)
         self.assertAlmostEqual(output[1][0],8.559512505657201897e-01,6)
@@ -288,7 +288,7 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertAlmostEqual(output[0][2],2.829585540991265358e+00,6)
         self.assertAlmostEqual(output[1][2],-6.510790587552289788e-01,6)
 
-    def testGalacticToEquatorial(self):
+    def testEquatorialFromGalactic(self):
 
         lon=numpy.zeros((3),dtype=float)
         lat=numpy.zeros((3),dtype=float)
@@ -300,7 +300,7 @@ class testCoordinateTransformations(unittest.TestCase):
         lon[2]=2.829585540991265358e+00
         lat[2]=-6.510790587552289788e-01
 
-        output=utils.galacticToEquatorial(lon,lat)
+        output=utils.equatorialFromGalactic(lon,lat)
 
         self.assertAlmostEqual(output[0][0],2.549091039839124218e+00,6)
         self.assertAlmostEqual(output[1][0],5.198752733024248895e-01,6)
@@ -310,10 +310,10 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertAlmostEqual(output[1][2],2.758053025017753179e-01,6)
 
 
-    def testSphericalToCartesian(self):
+    def testCartesianFromSpherical(self):
         arg1=2.19911485751
         arg2=5.96902604182
-        output=utils.sphericalToCartesian(arg1,arg2)
+        output=utils.cartesianFromSpherical(arg1,arg2)
 
         vv=numpy.zeros((3),dtype=float)
         vv[0]=numpy.cos(arg2)*numpy.cos(arg1)
@@ -325,7 +325,7 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertAlmostEqual(output[2],vv[2],7)
 
 
-    def testCartesianToSpherical(self):
+    def testSphericalFromCartesian(self):
         """
         Note that xyz[i][j] is the ith component of the jth vector
 
@@ -343,7 +343,7 @@ class testCoordinateTransformations(unittest.TestCase):
         xyz[2][1]=-9.876134719050078115e-02
         xyz[2][2]=-2.000636201137401038e+00
 
-        output=utils.cartesianToSpherical(xyz)
+        output=utils.sphericalFromCartesian(xyz)
 
         vv=numpy.zeros((3),dtype=float)
 
@@ -393,11 +393,11 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(v3[i],v2[i],7)
 
 
-    def testEquatorialToHorizontal(self):
+    def testHorizontalFromEquatorial(self):
         arg1=2.549091039839124218e+00
         arg2=5.198752733024248895e-01
         arg3=2.004031374869656474e+03
-        output=utils.equatorialToHorizontal(arg1,arg2,arg3,
+        output=utils.horizontalFromEquatorial(arg1,arg2,arg3,
         longitude=Site().longitude,latitude=Site().latitude)
 
         self.assertAlmostEqual(output[0],4.486633480937949336e-01,4)

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -397,16 +397,6 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v2, v1)
 
 
-    def testHorizontalFromEquatorial(self):
-        arg1=2.549091039839124218e+00
-        arg2=5.198752733024248895e-01
-        arg3=2.004031374869656474e+03
-        output=utils.horizontalFromEquatorial(arg1,arg2,arg3,
-        longitude=Site().longitude,latitude=Site().latitude)
-
-        self.assertAlmostEqual(output[0],4.486633480937949336e-01,4)
-        self.assertAlmostEqual(output[1],5.852620488358430961e+00,4)
-
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()


### PR DESCRIPTION
The bulk of this pull request is here and in sims_coordUtils.

Following my presentation to the UW group in May, I redesigned the API for the astrometry routines to be more consistent with community terminology (e.g. correctCoordinates became observedFromICRS since it takes International Celestial Reference Frame mean coordinates and converts them into observed coordinates).

I also re-organized sims_coordUtils so that methods that do not need to be a part of mixin classes stand alone in AstrometryUtils.py and CameraUtils.py

Finally, coordinate transformation methods were changed from, e.g. radiansToArcsec to arcsecFromRadians since, as Russell pointed out, this puts the units in the method name closer to the relevant quantities in the code, i.e.

myArcsec = arcsecFromRadians(myRadians)

rather than

myArcsec = radiansToArcsec(myRadians)

There are supporting pull requests in sims_catalogs_generation, sims_photUtils, sims_catUtils, and sims_maf.