### PR TITLE
Bugfix/sim 1732/mlt pho sim

### DIFF
--- a/python/lsst/sims/utils/fileMaps.py
+++ b/python/lsst/sims/utils/fileMaps.py
@@ -11,19 +11,52 @@ class SpecMap(object):
                   '(^lte)':'starSED/mlt',
                   '^(Exp|Inst|Burst|Const)':'galaxySED'}
 
-    def __init__(self, fileDict=None):
+    def __init__(self, fileDict=None, dirDict=None):
+        """
+        @param [in] fileDict is a dict mapping the names of files to their
+        relative paths, one-to-one, e.g.
+
+            fileDict = {'A.dat':'ssmSED/A.dat.gz',
+                        'Sa.dat':'ssmSED/Sa.dat.gz'}
+
+        @param [in] dirDict is a dict mapping forms of names of file to their
+        sub directories using regular expressions, e.g.
+
+            dirDict = {'(^km)|(^kp)':'starSED/kurucz',
+                       '(^bergeron)':'starSED/wDs'}
+
+        which maps files begining in either 'km' or 'kp' to files with
+        the same names in the directory starSED/kurucz and maps files
+        beginning with 'bergeron' to files with the same names in the
+        directory starSED/wDs
+
+        """
         if fileDict:
             self.fileDict = fileDict
         else:
             self.fileDict = {}
 
+        if dirDict:
+            self.dirDict = dirDict
+        else:
+            self.dirDict = {}
+
+
     def __setitem__(self, key, val):
         self.fileDict[key] = val
 
     def __getitem__(self, item):
+
         item = item.strip()
+
         if self.fileDict.has_key(item):
-            return self.D[item]
+            return self.fileDict[item]
+
+        for key, val in sorted(self.dirDict.iteritems()):
+            if re.match(key, item):
+                full_name = item if item.endswith('.gz') else item + '.gz'
+                return os.path.join(val, full_name)
+
         for key, val in sorted(self.subdir_map.iteritems()):
             if re.match(key, item):
                 full_name = item if item.endswith('.gz') else item + '.gz'

--- a/python/lsst/sims/utils/fileMaps.py
+++ b/python/lsst/sims/utils/fileMaps.py
@@ -30,6 +30,8 @@ class SpecMap(object):
         beginning with 'bergeron' to files with the same names in the
         directory starSED/wDs
 
+        These dicts will take precedence over the subdir_map that is defined
+        as a class member variable of the SpecMap class.
         """
         if fileDict:
             self.fileDict = fileDict

--- a/python/lsst/sims/utils/fileMaps.py
+++ b/python/lsst/sims/utils/fileMaps.py
@@ -4,23 +4,25 @@ import re
 __all__ = ["SpecMap", "defaultSpecMap"]
 
 class SpecMap(object):
+
     subdir_map = {'(^km)|(^kp)':'starSED/kurucz',
                   '(^bergeron)':'starSED/wDs',
                   '(^burrows)|(^(m|L|l)[0-9])':'starSED/old_mlt',
                   '(^lte)':'starSED/mlt',
                   '^(Exp|Inst|Burst|Const)':'galaxySED'}
-    def __init__(self, D=None):
-        if D:
-            self.D = D
+
+    def __init__(self, fileDict=None):
+        if fileDict:
+            self.fileDict = fileDict
         else:
-            self.D = {}
+            self.fileDict = {}
 
     def __setitem__(self, key, val):
-        self.D[key] = val
+        self.fileDict[key] = val
 
     def __getitem__(self, item):
         item = item.strip()
-        if self.D.has_key(item):
+        if self.fileDict.has_key(item):
             return self.D[item]
         for key, val in sorted(self.subdir_map.iteritems()):
             if re.match(key, item):
@@ -44,7 +46,7 @@ class SpecMap(object):
             return False
 
 defaultSpecMap = SpecMap(
-    {'A.dat':'ssmSED/A.dat.gz',
+    fileDict = {'A.dat':'ssmSED/A.dat.gz',
      'Sa.dat':'ssmSED/Sa.dat.gz',
      'O.dat':'ssmSED/O.dat.gz',
      'harris_V.dat':'ssmSED/harris_V.dat.gz',

--- a/tests/testFileMaps.py
+++ b/tests/testFileMaps.py
@@ -2,35 +2,34 @@ import os
 import unittest
 import lsst.utils.tests as utilsTests
 
-from lsst.sims.utils import defaultSpecMap
+from lsst.sims.utils import SpecMap, defaultSpecMap
 
-class FileMapTest(unittest.TestCase):
+class SpecMapTest(unittest.TestCase):
 
-
-    def verifyFile(self, file_name, dir_name):
+    def verifyFile(self, file_name, dir_name, testSpecMap = defaultSpecMap):
         """
-        Verify that specMap[file_name] results in os.path.join(dir_name, file_name+'.gz')
+        Verify that testSpecMap[file_name] results in os.path.join(dir_name, file_name+'.gz')
         """
-        test_name = defaultSpecMap[file_name]
+        test_name = testSpecMap[file_name]
         control_name = os.path.join(dir_name, file_name+'.gz')
         msg = '%s should map to %s; it actually maps to %s' % (file_name, control_name, test_name)
         self.assertEqual(test_name, control_name, msg=msg)
 
         add_space = file_name+' '
         self.assertNotEqual(add_space, file_name)
-        test_name = defaultSpecMap[add_space]
+        test_name = testSpecMap[add_space]
         msg = '%s should map to %s; it actually maps to %s' % (add_space, control_name, test_name)
         self.assertEqual(test_name, control_name, msg=msg)
 
         add_space = ' '+file_name
         self.assertNotEqual(add_space, file_name)
-        test_name = defaultSpecMap[add_space]
+        test_name = testSpecMap[add_space]
         msg = '%s should map to %s; it actually maps to %s' % (add_space, control_name, test_name)
         self.assertEqual(test_name, control_name, msg=msg)
 
         add_gz = file_name+'.gz'
         self.assertNotEqual(add_gz, file_name)
-        test_name = defaultSpecMap[add_gz]
+        test_name = testSpecMap[add_gz]
         msg = '%s should map to %s; it actually maps to %s' % (add_gz, control_name, test_name)
         self.assertEqual(test_name, control_name, msg=msg)
 
@@ -95,11 +94,69 @@ class FileMapTest(unittest.TestCase):
         self.verifyFile('Exp.40E08.02Z.spec', 'galaxySED')
         self.verifyFile('Burst.40E08.002Z.spec', 'galaxySED')
 
+
+    def testDirDict(self):
+        """
+        Test a user-defined SpecMap with a dirDict
+        """
+        dirDictTestMap = SpecMap(dirDict = {'(^lte)':'silly_sub_dir'})
+        self.verifyFile('lte_11111.txt', 'silly_sub_dir', testSpecMap=dirDictTestMap)
+        self.verifyFile('Const.79E06.002Z.spec', 'galaxySED', testSpecMap=dirDictTestMap)
+        self.verifyFile('Inst.79E06.02Z.spec', 'galaxySED', testSpecMap=dirDictTestMap)
+        self.verifyFile('Exp.40E08.02Z.spec', 'galaxySED', testSpecMap=dirDictTestMap)
+        self.verifyFile('Burst.40E08.002Z.spec', 'galaxySED', testSpecMap=dirDictTestMap)
+        self.verifyFile('km30_5000.fits_g10_5040', 'starSED/kurucz', testSpecMap=dirDictTestMap)
+        self.verifyFile('kp10_9000.fits_g40_9100', 'starSED/kurucz', testSpecMap=dirDictTestMap)
+        self.verifyFile('burrows+2006c91.21_T1400_g5.5_cf_0.3X', 'starSED/old_mlt', testSpecMap=dirDictTestMap)
+        self.verifyFile('L2_0Full.dat', 'starSED/old_mlt', testSpecMap=dirDictTestMap)
+        self.verifyFile('m5.1Full.dat', 'starSED/old_mlt', testSpecMap=dirDictTestMap)
+
+    def testFileDict(self):
+        """
+        Test a user-defined SpecMap with a fileDict
+        """
+        fileDictTestMap = SpecMap(fileDict = {'abcd.txt':'file_dict_test_dir/abcd.txt.gz'})
+
+        self.assertEqual(fileDictTestMap['abcd.txt'], 'file_dict_test_dir/abcd.txt.gz')
+        self.verifyFile('lte_11111.txt', 'starSED/mlt', testSpecMap=fileDictTestMap)
+        self.verifyFile('Const.79E06.002Z.spec', 'galaxySED', testSpecMap=fileDictTestMap)
+        self.verifyFile('Inst.79E06.02Z.spec', 'galaxySED', testSpecMap=fileDictTestMap)
+        self.verifyFile('Exp.40E08.02Z.spec', 'galaxySED', testSpecMap=fileDictTestMap)
+        self.verifyFile('Burst.40E08.002Z.spec', 'galaxySED', testSpecMap=fileDictTestMap)
+        self.verifyFile('km30_5000.fits_g10_5040', 'starSED/kurucz', testSpecMap=fileDictTestMap)
+        self.verifyFile('kp10_9000.fits_g40_9100', 'starSED/kurucz', testSpecMap=fileDictTestMap)
+        self.verifyFile('burrows+2006c91.21_T1400_g5.5_cf_0.3X', 'starSED/old_mlt', testSpecMap=fileDictTestMap)
+        self.verifyFile('L2_0Full.dat', 'starSED/old_mlt', testSpecMap=fileDictTestMap)
+        self.verifyFile('m5.1Full.dat', 'starSED/old_mlt', testSpecMap=fileDictTestMap)
+
+
+    def testFileAndDirDict(self):
+        """
+        Test a user-defined SpecMap with both a fileDict and a dirDict
+        """
+        testMap = SpecMap(fileDict={'abcd.txt':'file_dir/abcd.txt.gz'},
+                          dirDict={'(^burrows)':'dir_dir'})
+
+        self.assertEqual(testMap['abcd.txt'], 'file_dir/abcd.txt.gz')
+        self.verifyFile('lte_11111.txt', 'starSED/mlt', testSpecMap=testMap)
+        self.verifyFile('Const.79E06.002Z.spec', 'galaxySED', testSpecMap=testMap)
+        self.verifyFile('Inst.79E06.02Z.spec', 'galaxySED', testSpecMap=testMap)
+        self.verifyFile('Exp.40E08.02Z.spec', 'galaxySED', testSpecMap=testMap)
+        self.verifyFile('Burst.40E08.002Z.spec', 'galaxySED', testSpecMap=testMap)
+        self.verifyFile('km30_5000.fits_g10_5040', 'starSED/kurucz', testSpecMap=testMap)
+        self.verifyFile('kp10_9000.fits_g40_9100', 'starSED/kurucz', testSpecMap=testMap)
+        self.verifyFile('burrows+2006c91.21_T1400_g5.5_cf_0.3X', 'dir_dir', testSpecMap=testMap)
+        self.verifyFile('L2_0Full.dat', 'starSED/old_mlt', testSpecMap=testMap)
+        self.verifyFile('m5.1Full.dat', 'starSED/old_mlt', testSpecMap=testMap)
+
+
+
+
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()
     suites = []
-    suites += unittest.makeSuite(FileMapTest)
+    suites += unittest.makeSuite(SpecMapTest)
 
     return unittest.TestSuite(suites)
 


### PR DESCRIPTION
When we updated the sims_sed_library last week, the MLT dwarves were matched to SED files each with 58,500 lines in them.  PhoSim only allows SED files to have 24,999 lines in them, so I added a sub-folder to sims_sed_library/starSED/ that contains the MLT dwarf spectra clipped to meet this requirement.  I then wrote a SpecFileMap sub-class specifically for the PhoSim InstanceCatalogs so that MLT dwarf spectra names get mapped to that sub-directory.

There are pull requests in

sims_utils
sims_catalogs_measures
sims_catUtils
sims_sed_library

supporting this pull request