### PR TITLE
Feature/sim 1983/wavefront sensor methods

### DIFF
--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import palpy
 from lsst.sims.utils import arcsecFromRadians, cartesianFromSpherical, sphericalFromCartesian
 from lsst.sims.utils import radiansFromArcsec
@@ -53,7 +53,7 @@ def solarRaDec(mjd, epoch=2000.0):
     """
 
     solarRA, solarDec = _solarRaDec(mjd, epoch=epoch)
-    return numpy.degrees(solarRA), numpy.degrees(solarDec)
+    return np.degrees(solarRA), np.degrees(solarDec)
 
 
 def _distanceToSun(ra, dec, mjd, epoch=2000.0):
@@ -76,8 +76,8 @@ def _distanceToSun(ra, dec, mjd, epoch=2000.0):
 
     if hasattr(ra, '__len__'):
         return haversine(ra, dec,
-                         numpy.array([sunRa]*len(ra)),
-                         numpy.array([sunDec]*len(ra)))
+                         np.array([sunRa]*len(ra)),
+                         np.array([sunDec]*len(ra)))
 
     return haversine(ra, dec,sunRa, sunDec)
 
@@ -98,7 +98,7 @@ def distanceToSun(ra, dec, mjd, epoch=2000.0):
     @param [out] distance on the sky to the Sun in degrees
     """
 
-    return numpy.degrees(_distanceToSun(numpy.radians(ra), numpy.radians(dec),
+    return np.degrees(_distanceToSun(np.radians(ra), np.radians(dec),
                                         mjd, epoch=epoch))
 
 
@@ -156,7 +156,7 @@ def applyRefraction(zenithDistance, tanzCoeff, tan3zCoeff):
                            "applyRefraction.  The method won't know how to " +
                            "handle that.  Pass a numpy array.")
 
-    if isinstance(zenithDistance, numpy.ndarray):
+    if isinstance(zenithDistance, np.ndarray):
         refractedZenith = palpy.refzVector(zenithDistance, tanzCoeff, tan3zCoeff)
     else:
         refractedZenith=palpy.refz(zenithDistance, tanzCoeff, tan3zCoeff)
@@ -190,10 +190,10 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
 
     """
 
-    output = _applyPrecession(numpy.radians(ra), numpy.radians(dec),
+    output = _applyPrecession(np.radians(ra), np.radians(dec),
                               epoch=epoch, mjd=mjd)
 
-    return numpy.degrees(output)
+    return np.degrees(output)
 
 
 
@@ -240,10 +240,10 @@ def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
 
     # Apply rotation matrix
     xyz = cartesianFromSpherical(ra,dec)
-    xyz =  numpy.dot(rmat,xyz.transpose()).transpose()
+    xyz =  np.dot(rmat,xyz.transpose()).transpose()
 
     raOut,decOut = sphericalFromCartesian(xyz)
-    return numpy.array([raOut,decOut])
+    return np.array([raOut,decOut])
 
 
 def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
@@ -284,13 +284,13 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     (both in degrees)
     """
 
-    output = _applyProperMotion(numpy.radians(ra), numpy.radians(dec),
+    output = _applyProperMotion(np.radians(ra), np.radians(dec),
                                 radiansFromArcsec(pm_ra),
                                 radiansFromArcsec(pm_dec),
                                 radiansFromArcsec(parallax),
                                 v_rad, epoch=epoch, mjd=mjd)
 
-    return numpy.degrees(output)
+    return np.degrees(output)
 
 
 def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
@@ -357,9 +357,9 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
     #because PAL and ERFA expect proper motion in terms of "coordinate
     #angle; not true angle" (as stated in erfa/starpm.c documentation)
-    pm_ra_corrected = pm_ra/numpy.cos(dec)
+    pm_ra_corrected = pm_ra/np.cos(dec)
 
-    if isinstance(ra, numpy.ndarray):
+    if isinstance(ra, np.ndarray):
         if len(ra) != len(dec) or \
         len(ra) != len(pm_ra) or \
         len(ra) != len(pm_dec) or \
@@ -379,7 +379,7 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     else:
         raOut, decOut = palpy.pm(ra, dec, pm_ra_corrected, pm_dec, parallaxArcsec, v_rad, epoch, julianEpoch)
 
-    return numpy.array([raOut,decOut])
+    return np.array([raOut,decOut])
 
 
 
@@ -430,12 +430,12 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     else:
         px_in = None
 
-    output = _appGeoFromICRS(numpy.radians(ra), numpy.radians(dec),
+    output = _appGeoFromICRS(np.radians(ra), np.radians(dec),
                              pm_ra=pm_ra_in, pm_dec=pm_dec_in,
                              parallax=px_in, v_rad=v_rad, epoch=epoch, mjd=mjd)
 
 
-    return numpy.degrees(output)
+    return np.degrees(output)
 
 
 def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
@@ -478,16 +478,16 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
                         % (len(ra),len(dec)))
 
     if pm_ra is None:
-        pm_ra=numpy.zeros(len(ra))
+        pm_ra=np.zeros(len(ra))
 
     if pm_dec is None:
-        pm_dec=numpy.zeros(len(ra))
+        pm_dec=np.zeros(len(ra))
 
     if v_rad is None:
-        v_rad=numpy.zeros(len(ra))
+        v_rad=np.zeros(len(ra))
 
     if parallax is None:
-        parallax=numpy.zeros(len(ra))
+        parallax=np.zeros(len(ra))
 
     # Define star independent mean to apparent place parameters
     # palpy.mappa calculates the star-independent parameters
@@ -510,11 +510,11 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     # because PAL and ERFA expect proper motion in terms of "coordinate
     # angle; not true angle" (as stated in erfa/starpm.c documentation)
-    pm_ra_corrected = pm_ra/numpy.cos(dec)
+    pm_ra_corrected = pm_ra/np.cos(dec)
 
     raOut,decOut = palpy.mapqkVector(ra,dec,pm_ra_corrected,pm_dec,arcsecFromRadians(parallax),v_rad,prms)
 
-    return numpy.array([raOut,decOut])
+    return np.array([raOut,decOut])
 
 
 def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
@@ -559,7 +559,7 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     raOut, decOut = palpy.ampqkVector(ra, dec, params)
 
-    return numpy.array([raOut, decOut])
+    return np.array([raOut, decOut])
 
 
 def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
@@ -590,10 +590,10 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     the second row is the mean ICRS Dec (both in degrees)
     """
 
-    raOut, decOut = _icrsFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+    raOut, decOut = _icrsFromAppGeo(np.radians(ra), np.radians(dec),
                                     epoch=epoch, mjd=mjd)
 
-    return numpy.array([numpy.degrees(raOut), numpy.degrees(decOut)])
+    return np.array([np.degrees(raOut), np.degrees(decOut)])
 
 
 def observedFromAppGeo(ra, dec, includeRefraction = True,
@@ -628,20 +628,20 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
 
     if altAzHr:
         raDec, \
-        altAz = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+        altAz = _observedFromAppGeo(np.radians(ra), np.radians(dec),
                                             includeRefraction=includeRefraction,
                                             altAzHr=altAzHr, wavelength=wavelength,
                                             obs_metadata=obs_metadata)
 
-        return numpy.degrees(raDec), numpy.degrees(altAz)
+        return np.degrees(raDec), np.degrees(altAz)
 
     else:
-        output = _observedFromAppGeo(numpy.radians(ra), numpy.radians(dec),
+        output = _observedFromAppGeo(np.radians(ra), np.radians(dec),
                                             includeRefraction=includeRefraction,
                                             altAzHr=altAzHr, wavelength=wavelength,
                                             obs_metadata=obs_metadata)
 
-        return numpy.degrees(output)
+        return np.degrees(output)
 
 
 def _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction):
@@ -782,8 +782,8 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
         #palpy.de2h converts equatorial to horizon coordinates
         #
         az, alt = palpy.de2hVector(hourAngle, decOut, obs_metadata.site.latitude_rad)
-        return numpy.array([raOut, decOut]), numpy.array([alt, az])
-    return numpy.array([raOut, decOut])
+        return np.array([raOut, decOut]), np.array([alt, az])
+    return np.array([raOut, decOut])
 
 
 def appGeoFromObserved(ra, dec, includeRefraction = True,
@@ -812,12 +812,12 @@ def appGeoFromObserved(ra, dec, includeRefraction = True,
     in degrees)
     """
 
-    raOut, decOut = _appGeoFromObserved(numpy.radians(ra), numpy.radians(dec),
+    raOut, decOut = _appGeoFromObserved(np.radians(ra), np.radians(dec),
                                         includeRefraction=includeRefraction,
                                         wavelength=wavelength,
                                         obs_metadata=obs_metadata)
 
-    return numpy.array([numpy.degrees(raOut), numpy.degrees(decOut)])
+    return np.array([np.degrees(raOut), np.degrees(decOut)])
 
 
 def _appGeoFromObserved(ra, dec, includeRefraction = True,
@@ -862,7 +862,7 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
     obsPrms = _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
 
     raOut, decOut = palpy.oapqkVector('r', ra, dec, obsPrms)
-    return numpy.array([raOut, decOut])
+    return np.array([raOut, decOut])
 
 
 def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
@@ -915,12 +915,12 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
     else:
         parallax_in = None
 
-    output = _observedFromICRS(numpy.radians(ra), numpy.radians(dec),
+    output = _observedFromICRS(np.radians(ra), np.radians(dec),
                                pm_ra=pm_ra_in, pm_dec=pm_dec_in, parallax=parallax_in,
                                v_rad=v_rad, obs_metadata=obs_metadata, epoch=epoch,
                                includeRefraction=includeRefraction)
 
-    return numpy.degrees(output)
+    return np.degrees(output)
 
 
 
@@ -979,7 +979,7 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
     ra_out, dec_out = _observedFromAppGeo(ra_apparent, dec_apparent, obs_metadata=obs_metadata,
                                                includeRefraction = includeRefraction)
 
-    return numpy.array([ra_out,dec_out])
+    return np.array([ra_out,dec_out])
 
 
 def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=True):
@@ -1012,11 +1012,11 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
     RA and the second row is the mean ICRS Dec (both in degrees)
     """
 
-    ra_out, dec_out = _icrsFromObserved(numpy.radians(ra), numpy.radians(dec),
+    ra_out, dec_out = _icrsFromObserved(np.radians(ra), np.radians(dec),
                                         obs_metadata=obs_metadata,
                                         epoch=epoch, includeRefraction=includeRefraction)
 
-    return numpy.array([numpy.degrees(ra_out), numpy.degrees(dec_out)])
+    return np.array([np.degrees(ra_out), np.degrees(dec_out)])
 
 
 def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=True):
@@ -1069,4 +1069,4 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     ra_icrs, dec_icrs = _icrsFromAppGeo(ra_app, dec_app, epoch=epoch,
                                         mjd=obs_metadata.mjd)
 
-    return numpy.array([ra_icrs, dec_icrs])
+    return np.array([ra_icrs, dec_icrs])

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -589,9 +589,9 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     This method works in radians.
 
-    @param [in] ra in radians (apparent geocentric).  Must be a numpy array.
+    @param [in] ra in radians (apparent geocentric).  Can be a numpy array or a float.
 
-    @param [in] dec in radians (apparent geocentric).  Must be a numpy array.
+    @param [in] dec in radians (apparent geocentric).  Can be a numpy array or a float.
 
     @param [in] epoch is the julian epoch (in years) of the equinox against which to
     measure RA (default: 2000.0)
@@ -602,6 +602,8 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     @param [out] a 2-D numpy array in which the first row is the mean ICRS RA and
     the second row is the mean ICRS Dec (both in radians)
     """
+
+    are_arrays = _validate_inputs([ra, dec], "icrsFromAppGeo")
 
     # Define star independent mean to apparent place parameters
     # palpy.mappa calculates the star-independent parameters
@@ -615,7 +617,10 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     # date (MJD)
     params = palpy.mappa(epoch, mjd.TDB)
 
-    raOut, decOut = palpy.ampqkVector(ra, dec, params)
+    if are_arrays:
+        raOut, decOut = palpy.ampqkVector(ra, dec, params)
+    else:
+        raOut, decOut = palpy.ampqk(ra, dec, params)
 
     return np.array([raOut, decOut])
 
@@ -634,9 +639,9 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     This method works in degrees.
 
-    @param [in] ra in degrees (apparent geocentric).  Must be a numpy array.
+    @param [in] ra in degrees (apparent geocentric).  Can be a numpy array or a float.
 
-    @param [in] dec in degrees (apparent geocentric).  Must be a numpy array.
+    @param [in] dec in degrees (apparent geocentric).  Can be a numpy array or a float.
 
     @param [in] epoch is the julian epoch (in years) of the equinox against which to
     measure RA (default: 2000.0)

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -869,9 +869,9 @@ def appGeoFromObserved(ra, dec, includeRefraction = True,
 
     This method works in degrees.
 
-    @param [in] ra is observed RA (degrees).  Must be a numpy array.
+    @param [in] ra is observed RA (degrees).  Can be a numpy array or a float.
 
-    @param [in] dec is observed Dec (degrees).  Must be a numpy array.
+    @param [in] dec is observed Dec (degrees).  Can be a numpy array or a float.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -903,9 +903,9 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
 
     This method works in radians.
 
-    @param [in] ra is observed RA (radians).  Must be a numpy array.
+    @param [in] ra is observed RA (radians).  Can be a numpy array or a float.
 
-    @param [in] dec is observed Dec (radians).  Must be a numpy array.
+    @param [in] dec is observed Dec (radians).  Can be a numpy array or a float.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -919,6 +919,8 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
     in radians)
     """
 
+    are_arrays = _validate_inputs([ra, dec], "appGeoFromObserved")
+
     if obs_metadata is None:
         raise RuntimeError("Cannot call appGeoFromObserved without an obs_metadata")
 
@@ -928,13 +930,13 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
     if obs_metadata.mjd is None:
         raise RuntimeError("Cannot call appGeoFromObserved: obs_metadata has no mjd")
 
-    if len(ra)!=len(dec):
-        raise RuntimeError("You passed %d RAs but %d Decs to appGeoFromObserved" % \
-                           (len(ra), len(dec)))
-
     obsPrms = _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
 
-    raOut, decOut = palpy.oapqkVector('r', ra, dec, obsPrms)
+    if are_arrays:
+        raOut, decOut = palpy.oapqkVector('r', ra, dec, obsPrms)
+    else:
+        raOut, decOut = palpy.oapqk('r', ra, dec, obsPrms)
+
     return np.array([raOut, decOut])
 
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -1043,6 +1043,22 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
     """
 
+    if isinstance(ra, np.ndarray):
+        fill_value = np.zeros(len(ra))
+    else:
+        fill_value = 0.0
+
+    if pm_ra is None:
+        pm_ra = fill_value
+    if pm_dec is None:
+        pm_dec = fill_value
+    if parallax is None:
+        parallax = fill_value
+    if v_rad is None:
+        v_rad = fill_value
+
+    are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad], "observedFromICRS")
+
     if obs_metadata is None:
         raise RuntimeError("cannot call observedFromICRS; obs_metadata is none")
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -78,7 +78,7 @@ def _distanceToSun(ra, dec, mjd, epoch=2000.0):
 
     sunRa, sunDec = _solarRaDec(mjd, epoch=epoch)
 
-    return haversine(ra, dec,sunRa, sunDec)
+    return haversine(ra, dec, sunRa, sunDec)
 
 
 def distanceToSun(ra, dec, mjd, epoch=2000.0):
@@ -99,7 +99,7 @@ def distanceToSun(ra, dec, mjd, epoch=2000.0):
     """
 
     return np.degrees(_distanceToSun(np.radians(ra), np.radians(dec),
-                                        mjd, epoch=epoch))
+                                     mjd, epoch=epoch))
 
 
 def refractionCoefficients(wavelength=0.5, site=None):
@@ -121,16 +121,16 @@ def refractionCoefficients(wavelength=0.5, site=None):
     if site is None:
         raise RuntimeError("Cannot call refractionCoefficients; no site information")
 
-    #TODO the latitude in refco needs to be astronomical latitude,
-    #not geodetic latitude
-    _refcoOutput=palpy.refco(site.height,
-                        site.temperature_kelvin,
-                        site.pressure,
-                        site.humidity,
-                        wavelength ,
-                        site.latitude_rad,
-                        site.lapseRate,
-                        precision)
+    # TODO the latitude in refco needs to be astronomical latitude,
+    # not geodetic latitude
+    _refcoOutput = palpy.refco(site.height,
+                               site.temperature_kelvin,
+                               site.pressure,
+                               site.humidity,
+                               wavelength,
+                               site.latitude_rad,
+                               site.lapseRate,
+                               precision)
 
     return _refcoOutput[0], _refcoOutput[1]
 
@@ -159,7 +159,7 @@ def applyRefraction(zenithDistance, tanzCoeff, tan3zCoeff):
     if isinstance(zenithDistance, np.ndarray):
         refractedZenith = palpy.refzVector(zenithDistance, tanzCoeff, tan3zCoeff)
     else:
-        refractedZenith=palpy.refz(zenithDistance, tanzCoeff, tan3zCoeff)
+        refractedZenith = palpy.refz(zenithDistance, tanzCoeff, tan3zCoeff)
 
     return refractedZenith
 
@@ -196,7 +196,6 @@ def applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     return np.degrees(output)
 
 
-
 def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
     """
     _applyPrecession() applies precesion and nutation to coordinates between two epochs.
@@ -231,22 +230,22 @@ def _applyPrecession(ra, dec, epoch=2000.0, mjd=None):
         raise RuntimeError("You need to supply applyPrecession with an mjd")
 
     # Determine the precession and nutation
-    #palpy.prenut takes the julian epoch for the mean coordinates
-    #and the MJD for the the true coordinates
+    # palpy.prenut takes the julian epoch for the mean coordinates
+    # and the MJD for the the true coordinates
     #
-    #TODO it is not specified what this MJD should be (i.e. in which
-    #time system it should be reckoned)
-    rmat=palpy.prenut(epoch, mjd.TT)
+    # TODO it is not specified what this MJD should be (i.e. in which
+    # time system it should be reckoned)
+    rmat = palpy.prenut(epoch, mjd.TT)
 
     # Apply rotation matrix
-    xyz = cartesianFromSpherical(ra,dec)
-    xyz =  np.dot(rmat,xyz.transpose()).transpose()
+    xyz = cartesianFromSpherical(ra, dec)
+    xyz = np.dot(rmat, xyz.transpose()).transpose()
 
-    raOut,decOut = sphericalFromCartesian(xyz)
-    return np.array([raOut,decOut])
+    raOut, decOut = sphericalFromCartesian(xyz)
+    return np.array([raOut, decOut])
 
 
-def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
+def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad,
                       epoch=2000.0, mjd=None):
     """Applies proper motion between two epochs.
 
@@ -293,8 +292,8 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     return np.degrees(output)
 
 
-def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
-                      epoch=2000.0, mjd=None):
+def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad,
+                       epoch=2000.0, mjd=None):
     """Applies proper motion between two epochs.
 
     units:  ra (radians), dec (radians), pm_ra (radians/year), pm_dec
@@ -332,9 +331,9 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
 
     """
 
-    if isinstance(ra, list) or isinstance(dec, list) or \
-    isinstance(pm_ra, list) or isinstance(pm_dec, list) or \
-    isinstance(parallax, list) or isinstance(v_rad, list):
+    if (isinstance(ra, list) or isinstance(dec, list) or
+        isinstance(pm_ra, list) or isinstance(pm_dec, list) or
+        isinstance(parallax, list) or isinstance(v_rad, list)):
 
         raise RuntimeError("You tried to pass lists to applyPm. " +
                            "The method does not know how to handle lists. " +
@@ -343,8 +342,8 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     if mjd is None:
         raise RuntimeError("cannot call applyProperMotion; mjd is None")
 
-    parallaxArcsec=arcsecFromRadians(parallax)
-    #convert to Arcsec because that is what PALPY expects
+    parallaxArcsec = arcsecFromRadians(parallax)
+    # convert to Arcsec because that is what PALPY expects
 
     # Generate Julian epoch from MJD
     #
@@ -355,32 +354,32 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad, \
     # ephemerides
     julianEpoch = palpy.epj(mjd.TT)
 
-    #because PAL and ERFA expect proper motion in terms of "coordinate
-    #angle; not true angle" (as stated in erfa/starpm.c documentation)
+    # because PAL and ERFA expect proper motion in terms of "coordinate
+    # angle; not true angle" (as stated in erfa/starpm.c documentation)
     pm_ra_corrected = pm_ra/np.cos(dec)
 
     if isinstance(ra, np.ndarray):
-        if len(ra) != len(dec) or \
-        len(ra) != len(pm_ra) or \
-        len(ra) != len(pm_dec) or \
-        len(ra) != len(parallaxArcsec) or \
-        len(ra) != len(v_rad):
+        if ((len(ra) != len(dec) or
+            len(ra) != len(pm_ra) or
+            len(ra) != len(pm_dec) or
+            len(ra) != len(parallaxArcsec)) or
+           len(ra) != len(v_rad)):
 
             raise RuntimeError("You passed: " +
                                "%d RAs, " % len(ra) +
                                "%d Dec, " % len(dec) +
                                "%d pm_ras, " % len(pm_ra) +
                                "%d pm_decs, " % len(pm_dec) +
-                               "%d parallaxes, " % len(parallaxArcsec)+
+                               "%d parallaxes, " % len(parallaxArcsec) +
                                "%d v_rads " % len(v_rad) +
                                "to applyPm; those numbers need to be identical.")
 
-        raOut, decOut = palpy.pmVector(ra,dec,pm_ra_corrected,pm_dec,parallaxArcsec,v_rad, epoch, julianEpoch)
+        raOut, decOut = palpy.pmVector(ra, dec, pm_ra_corrected, pm_dec,
+                                       parallaxArcsec, v_rad, epoch, julianEpoch)
     else:
         raOut, decOut = palpy.pm(ra, dec, pm_ra_corrected, pm_dec, parallaxArcsec, v_rad, epoch, julianEpoch)
 
-    return np.array([raOut,decOut])
-
+    return np.array([raOut, decOut])
 
 
 def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
@@ -434,12 +433,11 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
                              pm_ra=pm_ra_in, pm_dec=pm_dec_in,
                              parallax=px_in, v_rad=v_rad, epoch=epoch, mjd=mjd)
 
-
     return np.degrees(output)
 
 
 def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
-                   v_rad=None, epoch=2000.0, mjd = None):
+                    v_rad=None, epoch=2000.0, mjd = None):
     """
     Convert the mean position (RA, Dec) in the International Celestial Reference
     System (ICRS) to the mean apparent geocentric position
@@ -482,16 +480,16 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
         fill_value = 0.0
 
     if pm_ra is None:
-        pm_ra=fill_value
+        pm_ra = fill_value
 
     if pm_dec is None:
-        pm_dec=fill_value
+        pm_dec = fill_value
 
     if v_rad is None:
-        v_rad=fill_value
+        v_rad = fill_value
 
     if parallax is None:
-        parallax=fill_value
+        parallax = fill_value
 
     are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, v_rad, parallax],
                                   ['ra', 'dec', 'pm_ra', 'pm_dec', 'v_rad',
@@ -508,7 +506,7 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     # epoch of mean equinox to be used (Julian)
     #
     # date (MJD)
-    prms=palpy.mappa(epoch, mjd.TDB)
+    prms = palpy.mappa(epoch, mjd.TDB)
 
     # palpy.mapqk does a quick mean to apparent place calculation using
     # the output of palpy.mappa
@@ -523,12 +521,12 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
 
     if are_arrays:
         raOut, decOut = palpy.mapqkVector(ra, dec, pm_ra_corrected, pm_dec,
-                                          arcsecFromRadians(parallax), v_rad,prms)
+                                          arcsecFromRadians(parallax), v_rad, prms)
     else:
         raOut, decOut = palpy.mapqk(ra, dec, pm_ra_corrected, pm_dec,
                                     arcsecFromRadians(parallax), v_rad, prms)
 
-    return np.array([raOut,decOut])
+    return np.array([raOut, decOut])
 
 
 def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
@@ -646,19 +644,18 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
     """
 
     if altAzHr:
-        raDec, \
-        altAz = _observedFromAppGeo(np.radians(ra), np.radians(dec),
-                                            includeRefraction=includeRefraction,
-                                            altAzHr=altAzHr, wavelength=wavelength,
-                                            obs_metadata=obs_metadata)
+        raDec, altAz = _observedFromAppGeo(np.radians(ra), np.radians(dec),
+                                           includeRefraction=includeRefraction,
+                                           altAzHr=altAzHr, wavelength=wavelength,
+                                           obs_metadata=obs_metadata)
 
         return np.degrees(raDec), np.degrees(altAz)
 
     else:
         output = _observedFromAppGeo(np.radians(ra), np.radians(dec),
-                                            includeRefraction=includeRefraction,
-                                            altAzHr=altAzHr, wavelength=wavelength,
-                                            obs_metadata=obs_metadata)
+                                     includeRefraction=includeRefraction,
+                                     altAzHr=altAzHr, wavelength=wavelength,
+                                     obs_metadata=obs_metadata)
 
         return np.degrees(output)
 
@@ -693,46 +690,45 @@ def _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
     yPolar = 0.0
 
     #
-    #palpy.aoppa computes star-independent parameters necessary for
-    #converting apparent place into observed place
-    #i.e. it calculates geodetic latitude, magnitude of diurnal aberration,
-    #refraction coefficients and the like based on data about the observation site
+    # palpy.aoppa computes star-independent parameters necessary for
+    # converting apparent place into observed place
+    # i.e. it calculates geodetic latitude, magnitude of diurnal aberration,
+    # refraction coefficients and the like based on data about the observation site
     #
-    #TODO: palpy.aoppa requires as its first argument
-    #the UTC time expressed as an MJD.  It is not clear to me
-    #how to actually calculate that.
-    if (includeRefraction == True):
-        obsPrms=palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
-                          obs_metadata.site.longitude_rad,
-                          obs_metadata.site.latitude_rad,
-                          obs_metadata.site.height,
-                          xPolar,
-                          yPolar,
-                          obs_metadata.site.temperature_kelvin,
-                          obs_metadata.site.pressure,
-                          obs_metadata.site.humidity,
-                          wavelength ,
-                          obs_metadata.site.lapseRate)
+    # TODO: palpy.aoppa requires as its first argument
+    # the UTC time expressed as an MJD.  It is not clear to me
+    # how to actually calculate that.
+    if includeRefraction is True:
+        obsPrms = palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
+                              obs_metadata.site.longitude_rad,
+                              obs_metadata.site.latitude_rad,
+                              obs_metadata.site.height,
+                              xPolar,
+                              yPolar,
+                              obs_metadata.site.temperature_kelvin,
+                              obs_metadata.site.pressure,
+                              obs_metadata.site.humidity,
+                              wavelength,
+                              obs_metadata.site.lapseRate)
     else:
-        #we can discard refraction by setting pressure and humidity to zero
-        obsPrms=palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
-                          obs_metadata.site.longitude_rad,
-                          obs_metadata.site.latitude_rad,
-                          obs_metadata.site.height,
-                          xPolar,
-                          yPolar,
-                          obs_metadata.site.temperature,
-                          0.0,
-                          0.0,
-                          wavelength ,
-                          obs_metadata.site.lapseRate)
-
+        # we can discard refraction by setting pressure and humidity to zero
+        obsPrms = palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
+                              obs_metadata.site.longitude_rad,
+                              obs_metadata.site.latitude_rad,
+                              obs_metadata.site.height,
+                              xPolar,
+                              yPolar,
+                              obs_metadata.site.temperature,
+                              0.0,
+                              0.0,
+                              wavelength,
+                              obs_metadata.site.lapseRate)
 
     return obsPrms
 
 
 def _observedFromAppGeo(ra, dec, includeRefraction = True,
-                       altAzHr=False, wavelength=0.5, obs_metadata = None):
+                        altAzHr=False, wavelength=0.5, obs_metadata = None):
     """
     Convert apparent geocentric (RA, Dec) to observed (RA, Dec).  More specifically:
     apply refraction and diurnal aberration.
@@ -773,34 +769,32 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
     if obs_metadata.mjd is None:
         raise RuntimeError("Cannot call observedFromAppGeo: obs_metadata has no mjd")
 
-
-
     obsPrms = _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
 
-    #palpy.aopqk does an apparent to observed place
-    #correction
+    # palpy.aopqk does an apparent to observed place
+    # correction
     #
-    #it corrects for diurnal aberration and refraction
-    #(using a fast algorithm for refraction in the case of
-    #a small zenith distance and a more rigorous algorithm
-    #for a large zenith distance)
+    # it corrects for diurnal aberration and refraction
+    # (using a fast algorithm for refraction in the case of
+    # a small zenith distance and a more rigorous algorithm
+    # for a large zenith distance)
     #
 
     if are_arrays:
-        azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqkVector(ra,dec,obsPrms)
+        azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqkVector(ra, dec, obsPrms)
     else:
         azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqk(ra, dec, obsPrms)
 
     #
-    #Note: this is a choke point.  Even the vectorized version of aopqk
-    #is expensive (it takes about 0.006 seconds per call)
+    # Note: this is a choke point.  Even the vectorized version of aopqk
+    # is expensive (it takes about 0.006 seconds per call)
     #
-    #Actually, this is only a choke point if you are dealing with zenith
-    #distances of greater than about 70 degrees
+    # Actually, this is only a choke point if you are dealing with zenith
+    # distances of greater than about 70 degrees
 
-    if altAzHr == True:
+    if altAzHr is True:
         #
-        #palpy.de2h converts equatorial to horizon coordinates
+        # palpy.de2h converts equatorial to horizon coordinates
         #
         if are_arrays:
             az, alt = palpy.de2hVector(hourAngle, decOut, obs_metadata.site.latitude_rad)
@@ -812,7 +806,7 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 
 
 def appGeoFromObserved(ra, dec, includeRefraction = True,
-                        wavelength=0.5, obs_metadata = None):
+                       wavelength=0.5, obs_metadata = None):
     """
     Convert observed (RA, Dec) to apparent geocentric (RA, Dec).  More
     specifically: undo the effects of refraction and diurnal aberration.
@@ -954,9 +948,8 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
     return np.degrees(output)
 
 
-
 def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
-                     obs_metadata=None, epoch=None, includeRefraction=True):
+                      obs_metadata=None, epoch=None, includeRefraction=True):
     """
     Convert mean position (RA, Dec) in the International Celestial Reference Frame
     to observed (RA, Dec)-like coordinates.
@@ -1009,10 +1002,10 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
     if v_rad is None:
         v_rad = fill_value
 
-    are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad],
-                                  ['ra', 'dec', 'pm_ra', 'pm_dec', 'parallax',
-                                  'v_rad'],
-                                  "observedFromICRS")
+    _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad],
+                     ['ra', 'dec', 'pm_ra', 'pm_dec', 'parallax',
+                     'v_rad'],
+                     "observedFromICRS")
 
     if obs_metadata is None:
         raise RuntimeError("cannot call observedFromICRS; obs_metadata is none")
@@ -1024,12 +1017,13 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
         raise RuntimeError("cannot call observedFromICRS; you have not specified an epoch")
 
     ra_apparent, dec_apparent = _appGeoFromICRS(ra, dec, pm_ra = pm_ra,
-             pm_dec = pm_dec, parallax = parallax, v_rad = v_rad, epoch = epoch, mjd=obs_metadata.mjd)
+                                                pm_dec = pm_dec, parallax = parallax,
+                                                v_rad = v_rad, epoch = epoch, mjd=obs_metadata.mjd)
 
     ra_out, dec_out = _observedFromAppGeo(ra_apparent, dec_apparent, obs_metadata=obs_metadata,
-                                               includeRefraction = includeRefraction)
+                                          includeRefraction = includeRefraction)
 
-    return np.array([ra_out,dec_out])
+    return np.array([ra_out, dec_out])
 
 
 def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=True):
@@ -1099,8 +1093,7 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     RA and the second row is the mean ICRS Dec (both in radians)
     """
 
-    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "icrsFromObserved")
-
+    _validate_inputs([ra, dec], ['ra', 'dec'], "icrsFromObserved")
 
     if obs_metadata is None:
         raise RuntimeError("cannot call icrsFromObserved; obs_metadata is None")
@@ -1110,7 +1103,6 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     if epoch is None:
         raise RuntimeError("cannot call icrsFromObserved; you have not specified an epoch")
-
 
     ra_app, dec_app = _appGeoFromObserved(ra, dec, obs_metadata=obs_metadata,
                                           includeRefraction=includeRefraction)

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -141,7 +141,7 @@ def applyRefraction(zenithDistance, tanzCoeff, tan3zCoeff):
     uses the quick PAL refco routine which approximates the refractin calculation
 
     @param [in] zenithDistance is unrefracted zenith distance of the source in radians.
-    Can either be a float or a numpy array (not a list).
+    Can either be a number or a numpy array (not a list).
 
     @param [in] tanzCoeff is the first output from refractionCoefficients (above)
 
@@ -258,20 +258,20 @@ def applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad,
     The function palpy.pm does not work properly if the parallax is below
     0.00045 arcseconds
 
-    @param [in] ra in degrees.  Can be a float or a numpy array (not a list).
+    @param [in] ra in degrees.  Can be a number or a numpy array (not a list).
 
-    @param [in] dec in degrees.  Can be a float or a numpy array (not a list).
+    @param [in] dec in degrees.  Can be a number or a numpy array (not a list).
 
     @param [in] pm_ra is ra proper motion multiplied by cos(Dec) in arcsec/year.
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
     @param [in] pm_dec is dec proper motion in arcsec/year.
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
-    @param [in] parallax in arcsec. Can be a float or a numpy array (not a list).
+    @param [in] parallax in arcsec. Can be a number or a numpy array (not a list).
 
     @param [in] v_rad is radial velocity in km/sec (positive if the object is receding).
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
     @param [in] epoch is epoch in Julian years (default: 2000.0)
 
@@ -305,20 +305,20 @@ def _applyProperMotion(ra, dec, pm_ra, pm_dec, parallax, v_rad,
     The function palpy.pm does not work properly if the parallax is below
     0.00045 arcseconds
 
-    @param [in] ra in radians.  Can be a float or a numpy array (not a list).
+    @param [in] ra in radians.  Can be a number or a numpy array (not a list).
 
-    @param [in] dec in radians.  Can be a float or a numpy array (not a list).
+    @param [in] dec in radians.  Can be a number or a numpy array (not a list).
 
     @param [in] pm_ra is ra proper motion multiplied by cos(Dec) in radians/year.
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
     @param [in] pm_dec is dec proper motion in radians/year.
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
-    @param [in] parallax in radians. Can be a float or a numpy array (not a list).
+    @param [in] parallax in radians. Can be a number or a numpy array (not a list).
 
     @param [in] v_rad is radial velocity in km/sec (positive if the object is receding).
-    Can be a float or a numpy array (not a list).
+    Can be a number or a numpy array (not a list).
 
     @param [in] epoch is epoch in Julian years (default: 2000.0)
 
@@ -392,9 +392,9 @@ def appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     (arcsec/year), parallax (arcsec), v_rad (km/sec; positive if receding),
     epoch (Julian years)
 
-    @param [in] ra in degrees (ICRS).  Can be a numpy array or a float.
+    @param [in] ra in degrees (ICRS).  Can be a numpy array or a number.
 
-    @param [in] dec in degrees (ICRS).  Can be a numpy array or a float.
+    @param [in] dec in degrees (ICRS).  Can be a numpy array or a number.
 
     @param [in] pm_ra is ra proper motion multiplied by cos(Dec) in arcsec/year
 
@@ -446,20 +446,20 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     (radians/year), parallax (radians), v_rad (km/sec; positive if receding),
     epoch (Julian years)
 
-    @param [in] ra in radians (ICRS).  Can be a numpy array or a float.
+    @param [in] ra in radians (ICRS).  Can be a numpy array or a number.
 
-    @param [in] dec in radians (ICRS).  Can be a numpy array or a float.
+    @param [in] dec in radians (ICRS).  Can be a numpy array or a number.
 
     @param [in] pm_ra is ra proper motion multiplied by cos(Dec) in radians/year.
-    Can be a numpy array or a float or None.
+    Can be a numpy array or a number or None.
 
     @param [in] pm_dec is dec proper motion in radians/year.
-    Can be a numpy array or a float or None.
+    Can be a numpy array or a number or None.
 
-    @param [in] parallax in radians.  Can be a numpy array or a float or None.
+    @param [in] parallax in radians.  Can be a numpy array or a number or None.
 
     @param [in] v_rad is radial velocity in km/sec (positive if the object is receding).
-    Can be a numpy array or a float or None.
+    Can be a numpy array or a number or None.
 
     @param [in] epoch is the julian epoch (in years) of the equinox against which to
     measure RA (default: 2000.0)
@@ -543,9 +543,9 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     This method works in radians.
 
-    @param [in] ra in radians (apparent geocentric).  Can be a numpy array or a float.
+    @param [in] ra in radians (apparent geocentric).  Can be a numpy array or a number.
 
-    @param [in] dec in radians (apparent geocentric).  Can be a numpy array or a float.
+    @param [in] dec in radians (apparent geocentric).  Can be a numpy array or a number.
 
     @param [in] epoch is the julian epoch (in years) of the equinox against which to
     measure RA (default: 2000.0)
@@ -593,9 +593,9 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
 
     This method works in degrees.
 
-    @param [in] ra in degrees (apparent geocentric).  Can be a numpy array or a float.
+    @param [in] ra in degrees (apparent geocentric).  Can be a numpy array or a number.
 
-    @param [in] dec in degrees (apparent geocentric).  Can be a numpy array or a float.
+    @param [in] dec in degrees (apparent geocentric).  Can be a numpy array or a number.
 
     @param [in] epoch is the julian epoch (in years) of the equinox against which to
     measure RA (default: 2000.0)
@@ -621,9 +621,9 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
 
     This method works in degrees.
 
-    @param [in] ra is geocentric apparent RA (degrees).  Can be a numpy array or a float.
+    @param [in] ra is geocentric apparent RA (degrees).  Can be a numpy array or a number.
 
-    @param [in] dec is geocentric apparent Dec (degrees).  Can be a numpy array or a float.
+    @param [in] dec is geocentric apparent Dec (degrees).  Can be a numpy array or a number.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -735,9 +735,9 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 
     This method works in radians.
 
-    @param [in] ra is geocentric apparent RA (radians).  Can be a numpy array or a float.
+    @param [in] ra is geocentric apparent RA (radians).  Can be a numpy array or a number.
 
-    @param [in] dec is geocentric apparent Dec (radians).  Can be a numpy array or a float.
+    @param [in] dec is geocentric apparent Dec (radians).  Can be a numpy array or a number.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -815,9 +815,9 @@ def appGeoFromObserved(ra, dec, includeRefraction = True,
 
     This method works in degrees.
 
-    @param [in] ra is observed RA (degrees).  Can be a numpy array or a float.
+    @param [in] ra is observed RA (degrees).  Can be a numpy array or a number.
 
-    @param [in] dec is observed Dec (degrees).  Can be a numpy array or a float.
+    @param [in] dec is observed Dec (degrees).  Can be a numpy array or a number.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -849,9 +849,9 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
 
     This method works in radians.
 
-    @param [in] ra is observed RA (radians).  Can be a numpy array or a float.
+    @param [in] ra is observed RA (radians).  Can be a numpy array or a number.
 
-    @param [in] dec is observed Dec (radians).  Can be a numpy array or a float.
+    @param [in] dec is observed Dec (radians).  Can be a numpy array or a number.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -897,21 +897,21 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
 
     This method works in degrees.
 
-    @param [in] ra is the unrefracted RA in degrees (ICRS).  Can be a numpy array or a float.
+    @param [in] ra is the unrefracted RA in degrees (ICRS).  Can be a numpy array or a number.
 
-    @param [in] dec is the unrefracted Dec in degrees (ICRS).  Can be a numpy array or a float.
+    @param [in] dec is the unrefracted Dec in degrees (ICRS).  Can be a numpy array or a number.
 
     @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] pm_dec is proper motion in dec (arcsec/yr)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] parallax is parallax in arcsec
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] v_rad is radial velocity (km/s)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -959,21 +959,21 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
     This method works in radians.
 
-    @param [in] ra is the unrefracted RA in radians (ICRS).  Can be a numpy array or a float.
+    @param [in] ra is the unrefracted RA in radians (ICRS).  Can be a numpy array or a number.
 
-    @param [in] dec is the unrefracted Dec in radians (ICRS).  Can be a numpy array or a float.
+    @param [in] dec is the unrefracted Dec in radians (ICRS).  Can be a numpy array or a number.
 
     @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] pm_dec is proper motion in dec (radians/yr)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] parallax is parallax in radians
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] v_rad is radial velocity (km/s)
-    Can be a numpy array or a float or None (default=None).
+    Can be a numpy array or a number or None (default=None).
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1040,9 +1040,9 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
 
     This method works in degrees.
 
-    @param [in] ra is the observed RA in degrees.  Can be a numpy array or a float.
+    @param [in] ra is the observed RA in degrees.  Can be a numpy array or a number.
 
-    @param [in] dec is the observed Dec in degrees.  Can be a numpy array or a float.
+    @param [in] dec is the observed Dec in degrees.  Can be a numpy array or a number.
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1077,9 +1077,9 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     This method works in radians.
 
-    @param [in] ra is the observed RA in radians.  Can be a numpy array or a float.
+    @param [in] ra is the observed RA in radians.  Can be a numpy array or a number.
 
-    @param [in] dec is the observed Dec in radians.  Can be a numpy array or a float.
+    @param [in] dec is the observed Dec in radians.  Can be a numpy array or a number.
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import palpy
+from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.sims.utils import arcsecFromRadians, cartesianFromSpherical, sphericalFromCartesian
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.utils import haversine
@@ -15,57 +16,6 @@ __all__ = ["_solarRaDec", "solarRaDec",
            "_appGeoFromObserved", "appGeoFromObserved",
            "_observedFromICRS", "observedFromICRS",
            "_icrsFromObserved", "icrsFromObserved"]
-
-
-def _validate_inputs(input_list, method_name):
-    """
-    This method will validate the inputs of the astrometry methods.
-
-    input_list is a list of the inputs passed to a an astrometry method.
-
-    method_name is the name of the method.
-
-    _validate_inputs will verify that all of the inputs in input_list are:
-
-    1) of the same type
-    2) either floats or numpy arrays
-    3) if they are numpy arrays, they all have the same length
-
-    If any of these criteria are violated, a RuntimeError will be raised
-
-    returns True if the inputs are numpy arrays; False if not
-    """
-
-    if isinstance(input_list[0], np.ndarray):
-        desired_type = np.ndarray
-    elif isinstance(input_list[0], np.float):
-        desired_type = np.float
-    else:
-        raise RuntimeError("The inputs to %s should all be either " % method_name
-                           + "floats or numpy arrays")
-
-    valid_type = True
-    for ii in input_list:
-        if not isinstance(ii, desired_type):
-            valid_type = False
-
-    if not valid_type:
-        raise RuntimeError("The inputs to %s should all be either " % method_name
-                           + "floats or numpy arrays")
-
-    if desired_type is np.ndarray:
-        same_length=True
-        for ii in input_list:
-            if len(ii) != len(input_list[0]):
-                same_length = False
-        if not same_length:
-            raise RuntimeError("The arrays input to %s " % method_name
-                               + "all need to have the same length")
-
-    if desired_type is np.ndarray:
-        return True
-
-    return False
 
 
 def _solarRaDec(mjd, epoch=2000.0):

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -698,7 +698,7 @@ def _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
     # TODO: palpy.aoppa requires as its first argument
     # the UTC time expressed as an MJD.  It is not clear to me
     # how to actually calculate that.
-    if includeRefraction is True:
+    if includeRefraction:
         obsPrms = palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
                               obs_metadata.site.longitude_rad,
                               obs_metadata.site.latitude_rad,
@@ -792,7 +792,7 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
     # Actually, this is only a choke point if you are dealing with zenith
     # distances of greater than about 70 degrees
 
-    if altAzHr is True:
+    if altAzHr:
         #
         # palpy.de2h converts equatorial to horizon coordinates
         #

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -1075,9 +1075,9 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
 
     This method works in degrees.
 
-    @param [in] ra is the observed RA in degrees.  Must be a numpy array.
+    @param [in] ra is the observed RA in degrees.  Can be a numpy array or a float.
 
-    @param [in] dec is the observed Dec in degrees.  Must be a numpy array.
+    @param [in] dec is the observed Dec in degrees.  Can be a numpy array or a float.
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1112,9 +1112,9 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     This method works in radians.
 
-    @param [in] ra is the observed RA in radians.  Must be a numpy array.
+    @param [in] ra is the observed RA in radians.  Can be a numpy array or a float.
 
-    @param [in] dec is the observed Dec in radians.  Must be a numpy array.
+    @param [in] dec is the observed Dec in radians.  Can be a numpy array or a float.
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1128,6 +1128,9 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     RA and the second row is the mean ICRS Dec (both in radians)
     """
 
+    are_arrays = _validate_inputs([ra, dec], "icrsFromObserved")
+
+
     if obs_metadata is None:
         raise RuntimeError("cannot call icrsFromObserved; obs_metadata is None")
 
@@ -1136,10 +1139,6 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     if epoch is None:
         raise RuntimeError("cannot call icrsFromObserved; you have not specified an epoch")
-
-    if len(ra)!=len(dec):
-        raise RuntimeError("You passed %d RAs but %d Decs to icrsFromObserved" % \
-                           (len(ra), len(dec)))
 
 
     ra_app, dec_app = _appGeoFromObserved(ra, dec, obs_metadata=obs_metadata,

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -494,6 +494,8 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
         parallax=fill_value
 
     are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, v_rad, parallax],
+                                  ['ra', 'dec', 'pm_ra', 'pm_dec', 'v_rad',
+                                  'parallax'],
                                   "appGeoFromICRS")
 
     # Define star independent mean to apparent place parameters
@@ -557,7 +559,7 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd = None):
     the second row is the mean ICRS Dec (both in radians)
     """
 
-    are_arrays = _validate_inputs([ra, dec], "icrsFromAppGeo")
+    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "icrsFromAppGeo")
 
     # Define star independent mean to apparent place parameters
     # palpy.mappa calculates the star-independent parameters
@@ -760,7 +762,7 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 
     """
 
-    are_arrays = _validate_inputs([ra, dec], "observedFromAppGeo")
+    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "observedFromAppGeo")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call observedFromAppGeo without an obs_metadata")
@@ -869,7 +871,7 @@ def _appGeoFromObserved(ra, dec, includeRefraction = True,
     in radians)
     """
 
-    are_arrays = _validate_inputs([ra, dec], "appGeoFromObserved")
+    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "appGeoFromObserved")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call appGeoFromObserved without an obs_metadata")
@@ -1007,7 +1009,10 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
     if v_rad is None:
         v_rad = fill_value
 
-    are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad], "observedFromICRS")
+    are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad],
+                                  ['ra', 'dec', 'pm_ra', 'pm_dec', 'parallax',
+                                  'v_rad'],
+                                  "observedFromICRS")
 
     if obs_metadata is None:
         raise RuntimeError("cannot call observedFromICRS; obs_metadata is none")
@@ -1094,7 +1099,7 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     RA and the second row is the mean ICRS Dec (both in radians)
     """
 
-    are_arrays = _validate_inputs([ra, dec], "icrsFromObserved")
+    are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "icrsFromObserved")
 
 
     if obs_metadata is None:

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -74,11 +74,6 @@ def _distanceToSun(ra, dec, mjd, epoch=2000.0):
 
     sunRa, sunDec = _solarRaDec(mjd, epoch=epoch)
 
-    if hasattr(ra, '__len__'):
-        return haversine(ra, dec,
-                         np.array([sunRa]*len(ra)),
-                         np.array([sunDec]*len(ra)))
-
     return haversine(ra, dec,sunRa, sunDec)
 
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -72,8 +72,8 @@ def _solarRaDec(mjd, epoch=2000.0):
     """
     Return the RA and Dec of the Sun in radians
 
-    @param [in] mjd is the date (TDB) in question as an MJD
-    (this is a float)
+    @param [in] mjd is the date represented as a
+    ModifiedJulianDate object.
 
     @param [in] epoch is the mean epoch of the coordinate system
     (default is 2000.0)
@@ -83,7 +83,7 @@ def _solarRaDec(mjd, epoch=2000.0):
     @param [out] Dec of Sun in radians
     """
 
-    params = palpy.mappa(epoch, mjd)
+    params = palpy.mappa(epoch, mjd.TDB)
     # params[4:7] is a unit vector pointing from the Sun
     # to the Earth (see the docstring for palpy.mappa)
 
@@ -94,8 +94,8 @@ def solarRaDec(mjd, epoch=2000.0):
     """
     Return the RA and Dec of the Sun in degrees
 
-    @param [in] mjd is the date (TDB) in question as an MJD
-    (this is a float)
+    @param [in] mjd is the date represented as a
+    ModifiedJulianDate object.
 
     @param [in] epoch is the mean epoch of the coordinate system
     (default is 2000.0)
@@ -117,8 +117,8 @@ def _distanceToSun(ra, dec, mjd, epoch=2000.0):
 
     @param [in] dec in radians
 
-    @param [in] mjd is the date (TDB) in question as an MJD
-    (this is a float)
+    @param [in] mjd is the date represented as a
+    ModifiedJulianDate object.
 
     @param [in] epoch is the epoch of the coordinate system
     (default is 2000.0)
@@ -139,8 +139,8 @@ def distanceToSun(ra, dec, mjd, epoch=2000.0):
 
     @param [in] dec in degrees
 
-    @param [in] mjd is the date (TDB) in question as an MJD
-    (this is a float)
+    @param [in] mjd is the date represented as a
+    ModifiedJulianDate object.
 
     @param [in] epoch is the epoch of the coordinate system
     (default is 2000.0)

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -671,9 +671,9 @@ def observedFromAppGeo(ra, dec, includeRefraction = True,
 
     This method works in degrees.
 
-    @param [in] ra is geocentric apparent RA (degrees).  Must be a numpy array.
+    @param [in] ra is geocentric apparent RA (degrees).  Can be a numpy array or a float.
 
-    @param [in] dec is geocentric apparent Dec (degrees).  Must be a numpy array.
+    @param [in] dec is geocentric apparent Dec (degrees).  Can be a numpy array or a float.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -787,9 +787,9 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 
     This method works in radians.
 
-    @param [in] ra is geocentric apparent RA (radians).  Must be a numpy array.
+    @param [in] ra is geocentric apparent RA (radians).  Can be a numpy array or a float.
 
-    @param [in] dec is geocentric apparent Dec (radians).  Must be a numpy array.
+    @param [in] dec is geocentric apparent Dec (radians).  Can be a numpy array or a float.
 
     @param [in] includeRefraction is a boolean to turn refraction on and off
 
@@ -810,6 +810,8 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
 
     """
 
+    are_arrays = _validate_inputs([ra, dec], "observedFromAppGeo")
+
     if obs_metadata is None:
         raise RuntimeError("Cannot call observedFromAppGeo without an obs_metadata")
 
@@ -819,9 +821,6 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
     if obs_metadata.mjd is None:
         raise RuntimeError("Cannot call observedFromAppGeo: obs_metadata has no mjd")
 
-    if len(ra)!=len(dec):
-        raise RuntimeError("You passed %d RAs but %d Decs to observedFromAppGeo" % \
-                           (len(ra), len(dec)))
 
 
     obsPrms = _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
@@ -835,7 +834,10 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
     #for a large zenith distance)
     #
 
-    azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqkVector(ra,dec,obsPrms)
+    if are_arrays:
+        azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqkVector(ra,dec,obsPrms)
+    else:
+        azimuth, zenith, hourAngle, decOut, raOut = palpy.aopqk(ra, dec, obsPrms)
 
     #
     #Note: this is a choke point.  Even the vectorized version of aopqk
@@ -848,7 +850,11 @@ def _observedFromAppGeo(ra, dec, includeRefraction = True,
         #
         #palpy.de2h converts equatorial to horizon coordinates
         #
-        az, alt = palpy.de2hVector(hourAngle, decOut, obs_metadata.site.latitude_rad)
+        if are_arrays:
+            az, alt = palpy.de2hVector(hourAngle, decOut, obs_metadata.site.latitude_rad)
+        else:
+            az, alt = palpy.de2h(hourAngle, decOut, obs_metadata.site.latitude_rad)
+
         return np.array([raOut, decOut]), np.array([alt, az])
     return np.array([raOut, decOut])
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -951,17 +951,21 @@ def observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None
 
     This method works in degrees.
 
-    @param [in] ra is the unrefracted RA in degrees (ICRS).  Must be a numpy array.
+    @param [in] ra is the unrefracted RA in degrees (ICRS).  Can be a numpy array or a float.
 
-    @param [in] dec is the unrefracted Dec in degrees (ICRS).  Must be a numpy array.
+    @param [in] dec is the unrefracted Dec in degrees (ICRS).  Can be a numpy array or a float.
 
     @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] pm_dec is proper motion in dec (arcsec/yr)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] parallax is parallax in arcsec
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] v_rad is radial velocity (km/s)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1010,17 +1014,21 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
     This method works in radians.
 
-    @param [in] ra is the unrefracted RA in radians (ICRS).  Must be a numpy array.
+    @param [in] ra is the unrefracted RA in radians (ICRS).  Can be a numpy array or a float.
 
-    @param [in] dec is the unrefracted Dec in radians (ICRS).  Must be a numpy array.
+    @param [in] dec is the unrefracted Dec in radians (ICRS).  Can be a numpy array or a float.
 
     @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] pm_dec is proper motion in dec (radians/yr)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] parallax is parallax in radians
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] v_rad is radial velocity (km/s)
+    Can be a numpy array or a float or None (default=None).
 
     @param [in] obs_metadata is an ObservationMetaData object describing the
     telescope pointing.
@@ -1043,10 +1051,6 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
 
     if epoch is None:
         raise RuntimeError("cannot call observedFromICRS; you have not specified an epoch")
-
-    if len(ra)!=len(dec):
-        raise RuntimeError("You passed %d RAs but %d Decs to observedFromICRS" % \
-                           (len(ra), len(dec)))
 
     ra_apparent, dec_apparent = _appGeoFromICRS(ra, dec, pm_ra = pm_ra,
              pm_dec = pm_dec, parallax = parallax, v_rad = v_rad, epoch = epoch, mjd=obs_metadata.mjd)

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -73,6 +73,7 @@ def _solarRaDec(mjd, epoch=2000.0):
     Return the RA and Dec of the Sun in radians
 
     @param [in] mjd is the date (TDB) in question as an MJD
+    (this is a float)
 
     @param [in] epoch is the mean epoch of the coordinate system
     (default is 2000.0)
@@ -94,6 +95,7 @@ def solarRaDec(mjd, epoch=2000.0):
     Return the RA and Dec of the Sun in degrees
 
     @param [in] mjd is the date (TDB) in question as an MJD
+    (this is a float)
 
     @param [in] epoch is the mean epoch of the coordinate system
     (default is 2000.0)
@@ -116,6 +118,7 @@ def _distanceToSun(ra, dec, mjd, epoch=2000.0):
     @param [in] dec in radians
 
     @param [in] mjd is the date (TDB) in question as an MJD
+    (this is a float)
 
     @param [in] epoch is the epoch of the coordinate system
     (default is 2000.0)
@@ -137,6 +140,7 @@ def distanceToSun(ra, dec, mjd, epoch=2000.0):
     @param [in] dec in degrees
 
     @param [in] mjd is the date (TDB) in question as an MJD
+    (this is a float)
 
     @param [in] epoch is the epoch of the coordinate system
     (default is 2000.0)

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def _validate_inputs(input_list, input_names, method_name):
     """
     This method will validate the inputs of other methods.
@@ -47,7 +48,7 @@ def _validate_inputs(input_list, input_names, method_name):
         raise RuntimeError(msg)
 
     if desired_type is np.ndarray:
-        same_length=True
+        same_length = True
         for ii in input_list:
             if len(ii) != len(input_list[0]):
                 same_length = False

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+def _validate_inputs(input_list, method_name):
+    """
+    This method will validate the inputs of other methods.
+
+    input_list is a list of the inputs passed to a method.
+
+    method_name is the name of the method whose input is being validated.
+
+    _validate_inputs will verify that all of the inputs in input_list are:
+
+    1) of the same type
+    2) either floats or numpy arrays
+    3) if they are numpy arrays, they all have the same length
+
+    If any of these criteria are violated, a RuntimeError will be raised
+
+    returns True if the inputs are numpy arrays; False if not
+    """
+
+    if isinstance(input_list[0], np.ndarray):
+        desired_type = np.ndarray
+    elif isinstance(input_list[0], np.float):
+        desired_type = np.float
+    else:
+        raise RuntimeError("The inputs to %s should all be either " % method_name
+                           + "floats or numpy arrays")
+
+    valid_type = True
+    for ii in input_list:
+        if not isinstance(ii, desired_type):
+            valid_type = False
+
+    if not valid_type:
+        raise RuntimeError("The inputs to %s should all be either " % method_name
+                           + "floats or numpy arrays")
+
+    if desired_type is np.ndarray:
+        same_length=True
+        for ii in input_list:
+            if len(ii) != len(input_list[0]):
+                same_length = False
+        if not same_length:
+            raise RuntimeError("The arrays input to %s " % method_name
+                               + "all need to have the same length")
+
+    if desired_type is np.ndarray:
+        return True
+
+    return False

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -1,10 +1,13 @@
 import numpy as np
 
-def _validate_inputs(input_list, method_name):
+def _validate_inputs(input_list, input_names, method_name):
     """
     This method will validate the inputs of other methods.
 
     input_list is a list of the inputs passed to a method.
+
+    input_name is a list of the variable names associated with
+    input_list
 
     method_name is the name of the method whose input is being validated.
 
@@ -24,17 +27,24 @@ def _validate_inputs(input_list, method_name):
     elif isinstance(input_list[0], np.float):
         desired_type = np.float
     else:
-        raise RuntimeError("The inputs to %s should all be the same type," % method_name
-                           + " either floats or numpy arrays")
+        raise RuntimeError("The arg %s imput to method %s " % (input_names[0], method_name)
+                           + "should be either a float or a numpy array")
 
     valid_type = True
-    for ii in input_list:
+    bad_names = []
+    for ii, nn in zip(input_list, input_names):
         if not isinstance(ii, desired_type):
             valid_type = False
+            bad_names.append(nn)
 
     if not valid_type:
-        raise RuntimeError("The inputs to %s should all be the same type," % method_name
-                           + " either floats or numpy arrays")
+        msg = "The input arguments:\n"
+        for nn in bad_names:
+            msg += "%s,\n" % nn
+        msg += "passed to %s " % method_name
+        msg += "need to be either floats or numpy arrays\n"
+        msg += "and the same type as the argument %s" % input_names[0]
+        raise RuntimeError(msg)
 
     if desired_type is np.ndarray:
         same_length=True

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numbers
 
 
 def _validate_inputs(input_list, input_names, method_name):
@@ -15,7 +16,7 @@ def _validate_inputs(input_list, input_names, method_name):
     _validate_inputs will verify that all of the inputs in input_list are:
 
     1) of the same type
-    2) either floats or numpy arrays
+    2) either numpy arrays or instances of numbers.Number (floats or ints)
     3) if they are numpy arrays, they all have the same length
 
     If any of these criteria are violated, a RuntimeError will be raised
@@ -25,11 +26,11 @@ def _validate_inputs(input_list, input_names, method_name):
 
     if isinstance(input_list[0], np.ndarray):
         desired_type = np.ndarray
-    elif isinstance(input_list[0], np.float):
-        desired_type = np.float
+    elif isinstance(input_list[0], numbers.Number):
+        desired_type = numbers.Number
     else:
         raise RuntimeError("The arg %s input to method %s " % (input_names[0], method_name)
-                           + "should be either a float or a numpy array")
+                           + "should be either a number or a numpy array")
 
     valid_type = True
     bad_names = []
@@ -43,7 +44,7 @@ def _validate_inputs(input_list, input_names, method_name):
         for nn in bad_names:
             msg += "%s,\n" % nn
         msg += "passed to %s " % method_name
-        msg += "need to be either floats or numpy arrays\n"
+        msg += "need to be either numbers or numpy arrays\n"
         msg += "and the same type as the argument %s" % input_names[0]
         raise RuntimeError(msg)
 

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -24,8 +24,8 @@ def _validate_inputs(input_list, method_name):
     elif isinstance(input_list[0], np.float):
         desired_type = np.float
     else:
-        raise RuntimeError("The inputs to %s should all be either " % method_name
-                           + "floats or numpy arrays")
+        raise RuntimeError("The inputs to %s should all be the same type," % method_name
+                           + " either floats or numpy arrays")
 
     valid_type = True
     for ii in input_list:
@@ -33,8 +33,8 @@ def _validate_inputs(input_list, method_name):
             valid_type = False
 
     if not valid_type:
-        raise RuntimeError("The inputs to %s should all be either " % method_name
-                           + "floats or numpy arrays")
+        raise RuntimeError("The inputs to %s should all be the same type," % method_name
+                           + " either floats or numpy arrays")
 
     if desired_type is np.ndarray:
         same_length=True

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -27,7 +27,7 @@ def _validate_inputs(input_list, input_names, method_name):
     elif isinstance(input_list[0], np.float):
         desired_type = np.float
     else:
-        raise RuntimeError("The arg %s imput to method %s " % (input_names[0], method_name)
+        raise RuntimeError("The arg %s input to method %s " % (input_names[0], method_name)
                            + "should be either a float or a numpy array")
 
     valid_type = True

--- a/python/lsst/sims/utils/CompoundCoordinateTransformations.py
+++ b/python/lsst/sims/utils/CompoundCoordinateTransformations.py
@@ -9,7 +9,7 @@ import numpy as np
 import palpy
 from collections import OrderedDict
 from lsst.sims.utils.CodeUtilities import _validate_inputs
-from lsst.sims.utils import _icrsFromObserved, _observedFromICRS, calcLmstLast, _observedFromAppGeo
+from lsst.sims.utils import _icrsFromObserved, _observedFromICRS, calcLmstLast
 from lsst.sims.utils import ObservationMetaData, Site, haversine
 
 __all__ = ["_altAzPaFromRaDec", "altAzPaFromRaDec",
@@ -17,7 +17,7 @@ __all__ = ["_altAzPaFromRaDec", "altAzPaFromRaDec",
            "getRotTelPos", "_getRotTelPos",
            "getRotSkyPos", "_getRotSkyPos",
            "calcObsDefaults", "makeObservationMetadata", "makeObsParamsAzAltTel",
-           "makeObsParamsAzAltSky", "makeObsParamsRaDecTel", "makeObsParamsRaDecSky",]
+           "makeObsParamsAzAltSky", "makeObsParamsRaDecTel", "makeObsParamsRaDecSky"]
 
 
 def altAzPaFromRaDec(ra, dec, obs):
@@ -45,7 +45,6 @@ def altAzPaFromRaDec(ra, dec, obs):
                                     obs)
 
     return np.degrees(alt), np.degrees(az), np.degrees(pa)
-
 
 
 def _altAzPaFromRaDec(raRad, decRad, obs):
@@ -131,18 +130,17 @@ def _raDecFromAltAz(altRad, azRad, obs):
     Note: This method is only accurate to within 0.01 arcsec near azimuth = 0 or pi
     """
 
-    are_arrays = _validate_inputs([altRad, azRad], ['altRad', 'azRad'],
-                                 "raDecFromAltAz")
+    are_arrays = _validate_inputs([altRad, azRad], ['altRad', 'azRad'], "raDecFromAltAz")
 
     lst = calcLmstLast(obs.mjd.UT1, obs.site.longitude_rad)
     last = lst[1]
     sinAlt = np.sin(altRad)
     cosLat = np.cos(obs.site.latitude_rad)
     sinLat = np.sin(obs.site.latitude_rad)
-    decObs = np.arcsin(sinLat*sinAlt+ cosLat*np.cos(altRad)*np.cos(azRad))
+    decObs = np.arcsin(sinLat*sinAlt + cosLat*np.cos(altRad)*np.cos(azRad))
     costheta = (sinAlt - np.sin(decObs)*sinLat)/(np.cos(decObs)*cosLat)
     if are_arrays:
-        haRad0 =  np.arccos(costheta)
+        haRad0 = np.arccos(costheta)
         # Make sure there were no NaNs
         nanSpots = np.where(np.isnan(haRad0))[0]
         if np.size(nanSpots) > 0:
@@ -150,12 +148,12 @@ def _raDecFromAltAz(altRad, azRad, obs):
     else:
         haRad0 = np.arccos(costheta)
         if np.isnan(haRad0):
-            if np.sign(costheta)>0.0:
+            if np.sign(costheta) > 0.0:
                 haRad0 = 0.0
             else:
                 haRad0 = np.pi
 
-    haRad = np.where(np.sin(azRad)>=0.0, -1.0*haRad0, haRad0)
+    haRad = np.where(np.sin(azRad) >= 0.0, -1.0*haRad0, haRad0)
     raObs = np.radians(last*15.) - haRad
 
     raRad, decRad = _icrsFromObserved(raObs, decObs,
@@ -195,7 +193,6 @@ def getRotSkyPos(ra, dec, obs, rotTel):
                            obs, np.radians(rotTel))
 
     return np.degrees(rotSky)
-
 
 
 def _getRotSkyPos(raRad, decRad, obs, rotTelRad):
@@ -331,7 +328,8 @@ def calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad,
     headers of its input InstanceCatalogs
     """
     obsMd = {}
-    #Defaults
+
+    # Defaults
     obsTemp = ObservationMetaData(mjd=mjd, site=Site(longitude=np.degrees(longRad),
                                                      latitude=np.degrees(latRad), name='LSST'))
     moonra, moondec = _raDecFromAltAz(-np.pi/2., 0., obsTemp)
@@ -356,11 +354,11 @@ def calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad,
 
 
 def makeObservationMetadata(metaData):
-    return OrderedDict([(k,(metaData[k], np.asarray(metaData[k]).dtype))
-                         for k in metaData])
+    return OrderedDict([(k, (metaData[k], np.asarray(metaData[k]).dtype)) for k in metaData])
 
 
-def makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=0., longRad=-1.2320792, latRad=-0.517781017, **kwargs):
+def makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=0.,
+                          longRad=-1.2320792, latRad=-0.517781017, **kwargs):
     '''
     Calculate a minimal set of observing parameters give the azimuth, altitude, and time of the observation.
     altRad -- Altitude of the boresite of the observation in radians
@@ -373,8 +371,10 @@ def makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=0., longRad=-1.232
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
 
-    obsTemp = ObservationMetaData(mjd=mjd, site=Site(longitude=np.degrees(longRad), latitude=np.degrees(latRad),
-                                                 name='LSST'))
+    obsTemp = ObservationMetaData(mjd=mjd,
+                                  site=Site(longitude=np.degrees(longRad),
+                                            latitude=np.degrees(latRad),
+                                            name='LSST'))
 
     raRad, decRad = _raDecFromAltAz(altRad, azRad, obsTemp)
     obsMd = calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad, latRad)
@@ -382,7 +382,8 @@ def makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=0., longRad=-1.232
     return makeObservationMetadata(obsMd)
 
 
-def makeObsParamsAzAltSky(azRad, altRad, mjd, band, rotSkyRad=np.pi, longRad=-1.2320792, latRad=-0.517781017, **kwargs):
+def makeObsParamsAzAltSky(azRad, altRad, mjd, band, rotSkyRad=np.pi,
+                          longRad=-1.2320792, latRad=-0.517781017, **kwargs):
     '''
     Calculate a minimal set of observing parameters give the azimuth, altitude, and time of the observation.
     altRad -- Altitude of the boresite of the observation in radians
@@ -394,14 +395,19 @@ def makeObsParamsAzAltSky(azRad, altRad, mjd, band, rotSkyRad=np.pi, longRad=-1.
     latRad -- Latitude of the observatory in radians Default=-0.517781017
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
-    obsTemp = ObservationMetaData(mjd=mjd, site=Site(longitude=np.degrees(longRad), latitude=np.degrees(latRad),
-                                                     name='LSST'))
+    obsTemp = ObservationMetaData(mjd=mjd,
+                                  site=Site(longitude=np.degrees(longRad),
+                                            latitude=np.degrees(latRad),
+                                            name='LSST'))
+
     raRad, decRad = _raDecFromAltAz(altRad, azRad, obsTemp)
     rotTelRad = _getRotTelPos(raRad, decRad, longRad, latRad, mjd, rotSkyRad)
-    return makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=rotTelRad, longRad=longRad, latRad=latRad, **kwargs)
+    return makeObsParamsAzAltTel(azRad, altRad, mjd, band, rotTelRad=rotTelRad,
+                                 longRad=longRad, latRad=latRad, **kwargs)
 
 
-def makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=0., longRad=-1.2320792, latRad=-0.517781017, **kwargs):
+def makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=0.,
+                          longRad=-1.2320792, latRad=-0.517781017, **kwargs):
     '''
     Calculate a minimal set of observing parameters give the ra, dec, and time of the observation.
     raRad -- RA of the boresite of the observation in radians
@@ -413,15 +419,19 @@ def makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=0., longRad=-1.232
     latRad -- Latitude of the observatory in radians Default=-0.517781017
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
-    obsTemp = ObservationMetaData(mjd=mjd, site=Site(longitude=np.degrees(longRad), latitude=np.degrees(latRad),
-                                                     name='LSST'))
+    obsTemp = ObservationMetaData(mjd=mjd,
+                                  site=Site(longitude=np.degrees(longRad),
+                                            latitude=np.degrees(latRad),
+                                            name='LSST'))
+
     altRad, azRad, paRad = altAzPaFromRaDec(raRad, decRad, obsTemp)
     obsMd = calcObsDefaults(raRad, decRad, altRad, azRad, rotTelRad, mjd, band, longRad, latRad)
     obsMd.update(kwargs)
     return makeObservationMetadata(obsMd)
 
 
-def makeObsParamsRaDecSky(raRad, decRad, mjd, band, rotSkyRad=np.pi, longRad=-1.2320792, latRad=-0.517781017, **kwargs):
+def makeObsParamsRaDecSky(raRad, decRad, mjd, band, rotSkyRad=np.pi,
+                          longRad=-1.2320792, latRad=-0.517781017, **kwargs):
     '''
     Calculate a minimal set of observing parameters give the ra, dec, and time of the observation.
     raRad -- RA of the boresite of the observation in radians
@@ -433,8 +443,12 @@ def makeObsParamsRaDecSky(raRad, decRad, mjd, band, rotSkyRad=np.pi, longRad=-1.
     latRad -- Latitude of the observatory in radians Default=-0.517781017
     **kwargs -- The kwargs will be put in the returned dictionary overriding the default value if it exists
     '''
-    obsTemp = ObservationMetaData(mjd=mjd, site=Site(longitude=np.degrees(longRad), latitude=np.degrees(latRad),
-                                                     name='LSST'))
+    obsTemp = ObservationMetaData(mjd=mjd,
+                                  site=Site(longitude=np.degrees(longRad),
+                                            latitude=np.degrees(latRad),
+                                            name='LSST'))
+
     rotTelRad = _getRotTelPos(raRad, decRad, obsTemp, rotSkyRad)
-    return makeObsParamsRaDecTel(raRad, decRad, mjd, band, rotTelRad=rotTelRad, longRad=longRad, latRad=latRad, **kwargs)
+    return makeObsParamsRaDecTel(raRad, decRad, mjd, band,
+                                 rotTelRad=rotTelRad, longRad=longRad, latRad=latRad, **kwargs)
 

--- a/python/lsst/sims/utils/CompoundCoordinateTransformations.py
+++ b/python/lsst/sims/utils/CompoundCoordinateTransformations.py
@@ -69,7 +69,8 @@ def _altAzPaFromRaDec(raRad, decRad, obs):
     @param [out] parallactic angle in radians
     """
 
-    are_arrays = _validate_inputs([raRad, decRad], "altAzPaFromRaDec")
+    are_arrays = _validate_inputs([raRad, decRad], ['ra', 'dec'],
+                                  "altAzPaFromRaDec")
 
     raObs, decObs = _observedFromICRS(raRad, decRad, obs_metadata=obs, epoch=2000.0, includeRefraction=True)
 
@@ -130,7 +131,8 @@ def _raDecFromAltAz(altRad, azRad, obs):
     Note: This method is only accurate to within 0.01 arcsec near azimuth = 0 or pi
     """
 
-    are_arrays = _validate_inputs([altRad, azRad], "raDecFromAltAz")
+    are_arrays = _validate_inputs([altRad, azRad], ['altRad', 'azRad'],
+                                 "raDecFromAltAz")
 
     lst = calcLmstLast(obs.mjd.UT1, obs.site.longitude_rad)
     last = lst[1]

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -3,7 +3,7 @@ This file contains coordinate transformation methods that are very thin wrappers
 of palpy methods, or that have no dependence on palpy at all
 """
 
-import numpy
+import numpy as np
 import palpy
 from collections import OrderedDict
 
@@ -34,10 +34,10 @@ def calcLmstLast(mjd, longRad):
     """
     mjdIsArray = False
     longRadIsArray = False
-    if isinstance(mjd, numpy.ndarray):
+    if isinstance(mjd, np.ndarray):
         mjdIsArray = True
 
-    if isinstance(longRad, numpy.ndarray):
+    if isinstance(longRad, np.ndarray):
         longRadIsArray = True
 
     if longRadIsArray and mjdIsArray:
@@ -46,11 +46,11 @@ def calcLmstLast(mjd, longRad):
 
 
     valid_type = False
-    if isinstance(mjd, numpy.ndarray) and isinstance(longRad, numpy.ndarray):
+    if isinstance(mjd, np.ndarray) and isinstance(longRad, np.ndarray):
         valid_type = True
-    elif isinstance(mjd, numpy.ndarray) and isinstance(longRad, numpy.float):
+    elif isinstance(mjd, np.ndarray) and isinstance(longRad, np.float):
         valid_type = True
-    elif isinstance(mjd, numpy.float) and isinstance(longRad, numpy.float):
+    elif isinstance(mjd, np.float) and isinstance(longRad, np.float):
         valid_type = True
 
     if not valid_type:
@@ -59,11 +59,11 @@ def calcLmstLast(mjd, longRad):
                            "mjd as a numpy array and longRad as a float\n"
                            "mjd as a float and longRad as a float\n")
 
-    longDeg0 = numpy.degrees(longRad)
+    longDeg0 = np.degrees(longRad)
     longDeg0 %= 360.0
 
     if longRadIsArray:
-        longDeg = numpy.where(longDeg0>180.0, longDeg0-360.0, longDeg0)
+        longDeg = np.where(longDeg0>180.0, longDeg0-360.0, longDeg0)
     else:
         if longDeg0 > 180.:
             longDeg = longDeg0-360.
@@ -91,8 +91,8 @@ def galacticFromEquatorial(ra, dec):
     @param [out] gLat is galactic latitude in degrees
     '''
 
-    gLong, gLat = _galacticFromEquatorial(numpy.radians(ra), numpy.radians(dec))
-    return numpy.degrees(gLong), numpy.degrees(gLat)
+    gLong, gLat = _galacticFromEquatorial(np.radians(ra), np.radians(dec))
+    return np.degrees(gLong), np.degrees(gLat)
 
 
 def _galacticFromEquatorial(ra, dec):
@@ -109,7 +109,7 @@ def _galacticFromEquatorial(ra, dec):
     @param [out] gLat is galactic latitude in radians
     '''
 
-    if isinstance(ra, numpy.ndarray):
+    if isinstance(ra, np.ndarray):
         gLong, gLat = palpy.eqgalVector(ra, dec)
     else:
         gLong, gLat = palpy.eqgal(ra, dec)
@@ -131,8 +131,8 @@ def equatorialFromGalactic(gLong, gLat):
     @param [out] dec is declination in degrees
     '''
 
-    ra, dec = _equatorialFromGalactic(numpy.radians(gLong), numpy.radians(gLat))
-    return numpy.degrees(ra), numpy.degrees(dec)
+    ra, dec = _equatorialFromGalactic(np.radians(gLong), np.radians(gLat))
+    return np.degrees(ra), np.degrees(dec)
 
 
 def _equatorialFromGalactic(gLong, gLat):
@@ -149,7 +149,7 @@ def _equatorialFromGalactic(gLong, gLat):
     @param [out] dec is declination in radians (J2000)
     '''
 
-    if isinstance(gLong, numpy.ndarray):
+    if isinstance(gLong, np.ndarray):
         ra, dec = palpy.galeqVector(gLong, gLat)
     else:
         ra, dec = palpy.galeq(gLong, gLat)
@@ -170,13 +170,13 @@ def cartesianFromSpherical(longitude, latitude):
     All angles are in radians
     """
 
-    if not isinstance(longitude, numpy.ndarray) or not isinstance(latitude, numpy.ndarray):
+    if not isinstance(longitude, np.ndarray) or not isinstance(latitude, np.ndarray):
         raise RuntimeError("you need to pass numpy arrays to cartesianFromSpherical")
 
-    cosDec = numpy.cos(latitude)
-    return numpy.array([numpy.cos(longitude)*cosDec,
-                      numpy.sin(longitude)*cosDec,
-                      numpy.sin(latitude)]).transpose()
+    cosDec = np.cos(latitude)
+    return np.array([np.cos(longitude)*cosDec,
+                      np.sin(longitude)*cosDec,
+                      np.sin(latitude)]).transpose()
 
 
 def sphericalFromCartesian(xyz):
@@ -191,17 +191,17 @@ def sphericalFromCartesian(xyz):
     All angles are in radians
     """
 
-    if not isinstance(xyz, numpy.ndarray):
+    if not isinstance(xyz, np.ndarray):
         raise RuntimeError("you need to pass a numpy array to sphericalFromCartesian")
 
     if len(xyz.shape)>1:
-        rad = numpy.sqrt(numpy.power(xyz,2).sum(axis=1))
-        longitude = numpy.arctan2( xyz[:,1], xyz[:,0])
-        latitude = numpy.arcsin( xyz[:,2] / rad)
+        rad = np.sqrt(np.power(xyz,2).sum(axis=1))
+        longitude = np.arctan2( xyz[:,1], xyz[:,0])
+        latitude = np.arcsin( xyz[:,2] / rad)
     else:
-        rad = numpy.sqrt(numpy.dot(xyz,xyz))
-        longitude = numpy.arctan2(xyz[1], xyz[0])
-        latitude = numpy.arcsin(xyz[2]/rad)
+        rad = np.sqrt(np.dot(xyz,xyz))
+        longitude = np.arctan2(xyz[1], xyz[0])
+        latitude = np.arcsin(xyz[2]/rad)
 
     return longitude, latitude
 
@@ -216,20 +216,20 @@ def rotationMatrixFromVectors(v1, v2):
 
     '''
 
-    if numpy.abs(numpy.sqrt(numpy.dot(v1,v1))-1.0) > 0.01:
+    if np.abs(np.sqrt(np.dot(v1,v1))-1.0) > 0.01:
         raise RuntimeError("v1 in rotationMatrixFromVectors is not a unit vector")
 
-    if numpy.abs(numpy.sqrt(numpy.dot(v2,v2))-1.0) > 0.01:
+    if np.abs(np.sqrt(np.dot(v2,v2))-1.0) > 0.01:
         raise RuntimeError("v2 in rotationMatrixFromVectors is not a unit vector")
 
     # Calculate the axis of rotation by the cross product of v1 and v2
-    cross = numpy.cross(v1,v2)
-    cross = cross / numpy.sqrt(numpy.dot(cross,cross))
+    cross = np.cross(v1,v2)
+    cross = cross / np.sqrt(np.dot(cross,cross))
 
     # calculate the angle of rotation via dot product
-    angle  = numpy.arccos(numpy.dot(v1,v2))
-    sinDot = numpy.sin(angle)
-    cosDot = numpy.cos(angle)
+    angle  = np.arccos(np.dot(v1,v2))
+    sinDot = np.sin(angle)
+    cosDot = np.cos(angle)
 
     # calculate the corresponding rotation matrix
     # http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle
@@ -254,7 +254,7 @@ def equationOfEquinoxes(d):
     @param [out] the equation of equinoxes in radians.
     """
 
-    if isinstance(d, numpy.ndarray):
+    if isinstance(d, np.ndarray):
         return palpy.eqeqxVector(d)
     else:
         return palpy.eqeqx(d)
@@ -272,9 +272,9 @@ def calcGmstGast(mjd):
     @param [out] gast Greenwich apparent sidereal time in hours
     """
 
-    date = numpy.floor(mjd)
+    date = np.floor(mjd)
     ut1 = mjd-date
-    if isinstance(mjd, numpy.ndarray):
+    if isinstance(mjd, np.ndarray):
         gmst = palpy.gmstaVector(date, ut1)
     else:
         gmst = palpy.gmsta(date, ut1)
@@ -282,10 +282,10 @@ def calcGmstGast(mjd):
     eqeq = equationOfEquinoxes(mjd)
     gast = gmst + eqeq
 
-    gmst = gmst*24.0/(2.0*numpy.pi)
+    gmst = gmst*24.0/(2.0*np.pi)
     gmst %= 24.0
 
-    gast = gast*24.0/(2.0*numpy.pi)
+    gast = gast*24.0/(2.0*np.pi)
     gast %= 24.0
 
     return gmst, gast
@@ -307,9 +307,9 @@ def haversine(long1, lat1, long2, lat2):
 
     From http://en.wikipedia.org/wiki/Haversine_formula
     """
-    t1 = numpy.sin(lat2/2.-lat1/2.)**2
-    t2 = numpy.cos(lat1)*numpy.cos(lat2)*numpy.sin(long2/2. - long1/2.)**2
-    return 2*numpy.arcsin(numpy.sqrt(t1 + t2))
+    t1 = np.sin(lat2/2.-lat1/2.)**2
+    t2 = np.cos(lat1)*np.cos(lat2)*np.sin(long2/2. - long1/2.)**2
+    return 2*np.arcsin(np.sqrt(t1 + t2))
 
 
 def arcsecFromRadians(value):
@@ -321,7 +321,7 @@ def arcsecFromRadians(value):
     if value is None:
         return None
 
-    return 3600.0*numpy.degrees(value)
+    return 3600.0*np.degrees(value)
 
 
 def radiansFromArcsec(value):
@@ -333,7 +333,7 @@ def radiansFromArcsec(value):
     if value is None:
         return None
 
-    return numpy.radians(value/3600.0)
+    return np.radians(value/3600.0)
 
 
 def arcsecFromDegrees(value):

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -161,17 +161,28 @@ def cartesianFromSpherical(longitude, latitude):
     """
     Transforms between spherical and Cartesian coordinates.
 
-    @param [in] longitude is a numpy array of longitudes
+    @param [in] longitude is a numpy array or a float in radians
 
-    @param [in] latitude is a numpy array of latitudes
+    @param [in] latitude is a numpy array or float in radians
 
-    @param [out] a numpy array of the (three-dimensional) cartesian coordinates on a unit sphere
+    @param [out] a numpy array of the (three-dimensional) cartesian coordinates on a unit sphere.
+
+    if inputs are numpy arrays:
+    output[i][0] will be the x-coordinate of the ith point
+    output[i][1] will be the y-coordinate of the ith point
+    output[i][2] will be the z-coordinate of the ith point
 
     All angles are in radians
     """
 
-    if not isinstance(longitude, np.ndarray) or not isinstance(latitude, np.ndarray):
-        raise RuntimeError("you need to pass numpy arrays to cartesianFromSpherical")
+    valid_type = False
+    if isinstance(longitude, np.ndarray) and isinstance(latitude, np.ndarray):
+        valid_type = True
+    elif isinstance(longitude, np.float) and isinstance(latitude, np.float):
+        valid_type = True
+
+    if not valid_type:
+        raise RuntimeError("longitude and latitude must both be either numpy arrays or a floats")
 
     cosDec = np.cos(latitude)
     return np.array([np.cos(longitude)*cosDec,

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -44,8 +44,20 @@ def calcLmstLast(mjd, longRad):
         if len(longRad) != len(mjd):
             raise RuntimeError("in calcLmstLast mjd and longRad have different lengths")
 
-    if longRadIsArray and not mjdIsArray:
-        raise RuntimeError("in calcLmstLast longRad is numpy array but mjd is not")
+
+    valid_type = False
+    if isinstance(mjd, numpy.ndarray) and isinstance(longRad, numpy.ndarray):
+        valid_type = True
+    elif isinstance(mjd, numpy.ndarray) and isinstance(longRad, numpy.float):
+        valid_type = True
+    elif isinstance(mjd, numpy.float) and isinstance(longRad, numpy.float):
+        valid_type = True
+
+    if not valid_type:
+        raise RuntimeError("Valid input types for calcLmstLast are:\n"
+                           "mjd and longRad as numpy arrays of the same length\n"
+                           "mjd as a numpy array and longRad as a float\n"
+                           "mjd as a float and longRad as a float\n")
 
     longDeg0 = numpy.degrees(longRad)
     longDeg0 %= 360.0

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -4,6 +4,7 @@ of palpy methods, or that have no dependence on palpy at all
 """
 
 import numpy as np
+import numbers
 import palpy
 
 __all__ = ["_galacticFromEquatorial", "galacticFromEquatorial",
@@ -46,16 +47,16 @@ def calcLmstLast(mjd, longRad):
     valid_type = False
     if isinstance(mjd, np.ndarray) and isinstance(longRad, np.ndarray):
         valid_type = True
-    elif isinstance(mjd, np.ndarray) and isinstance(longRad, np.float):
+    elif isinstance(mjd, np.ndarray) and isinstance(longRad, numbers.Number):
         valid_type = True
-    elif isinstance(mjd, np.float) and isinstance(longRad, np.float):
+    elif isinstance(mjd, numbers.Number) and isinstance(longRad, numbers.Number):
         valid_type = True
 
     if not valid_type:
         msg = "Valid input types for calcLmstLast are:\n" \
               "mjd and longRad as numpy arrays of the same length\n" \
-              "mjd as a numpy array and longRad as a float\n" \
-              "mjd as a float and longRad as a float\n" \
+              "mjd as a numpy array and longRad as a number\n" \
+              "mjd as a number and longRad as a number\n" \
               "You gave mjd: %s\n" % type(mjd) \
               + "and longRad: %s\n" % type(longRad)
 
@@ -84,9 +85,9 @@ def calcLmstLast(mjd, longRad):
 def galacticFromEquatorial(ra, dec):
     '''Convert RA,Dec (J2000) to Galactic Coordinates
 
-    @param [in] ra is right ascension in degrees, either a float or a numpy array
+    @param [in] ra is right ascension in degrees, either a number or a numpy array
 
-    @param [in] dec is declination in degrees, either a float or a numpy array
+    @param [in] dec is declination in degrees, either a number or a numpy array
 
     @param [out] gLong is galactic longitude in degrees
 
@@ -102,9 +103,9 @@ def _galacticFromEquatorial(ra, dec):
 
     All angles are in radians
 
-    @param [in] ra is right ascension in radians, either a float or a numpy array
+    @param [in] ra is right ascension in radians, either a number or a numpy array
 
-    @param [in] dec is declination in radians, either a float or a numpy array
+    @param [in] dec is declination in radians, either a number or a numpy array
 
     @param [out] gLong is galactic longitude in radians
 
@@ -122,10 +123,10 @@ def _galacticFromEquatorial(ra, dec):
 def equatorialFromGalactic(gLong, gLat):
     '''Convert Galactic Coordinates to RA, dec (J2000)
 
-    @param [in] gLong is galactic longitude in degrees, either a float or a numpy array
+    @param [in] gLong is galactic longitude in degrees, either a number or a numpy array
     (0 <= gLong <= 360.)
 
-    @param [in] gLat is galactic latitude in degrees, either a float or a numpy array
+    @param [in] gLat is galactic latitude in degrees, either a number or a numpy array
     (-90. <= gLat <= 90.)
 
     @param [out] ra is right ascension in degrees
@@ -140,10 +141,10 @@ def equatorialFromGalactic(gLong, gLat):
 def _equatorialFromGalactic(gLong, gLat):
     '''Convert Galactic Coordinates to RA, dec (J2000)
 
-    @param [in] gLong is galactic longitude in radians, either a float or a numpy array
+    @param [in] gLong is galactic longitude in radians, either a number or a numpy array
     (0 <= gLong <= 2*pi)
 
-    @param [in] gLat is galactic latitude in radians, either a float or a numpy array
+    @param [in] gLat is galactic latitude in radians, either a number or a numpy array
     (-pi/2 <= gLat <= pi/2)
 
     @param [out] ra is right ascension in radians (J2000)
@@ -163,9 +164,9 @@ def cartesianFromSpherical(longitude, latitude):
     """
     Transforms between spherical and Cartesian coordinates.
 
-    @param [in] longitude is a numpy array or a float in radians
+    @param [in] longitude is a numpy array or a number in radians
 
-    @param [in] latitude is a numpy array or float in radians
+    @param [in] latitude is a numpy array or number in radians
 
     @param [out] a numpy array of the (three-dimensional) cartesian coordinates on a unit sphere.
 
@@ -180,11 +181,11 @@ def cartesianFromSpherical(longitude, latitude):
     valid_type = False
     if isinstance(longitude, np.ndarray) and isinstance(latitude, np.ndarray):
         valid_type = True
-    elif isinstance(longitude, np.float) and isinstance(latitude, np.float):
+    elif isinstance(longitude, numbers.Number) and isinstance(latitude, numbers.Number):
         valid_type = True
 
     if not valid_type:
-        raise RuntimeError("longitude and latitude must both be either numpy arrays or a floats")
+        raise RuntimeError("longitude and latitude must both be either numpy arrays or numbers")
 
     cosDec = np.cos(latitude)
     return np.array([np.cos(longitude)*cosDec, np.sin(longitude)*cosDec, np.sin(latitude)]).transpose()
@@ -258,7 +259,7 @@ def equationOfEquinoxes(d):
     """
     The equation of equinoxes. See http://aa.usno.navy.mil/faq/docs/GAST.php
 
-    @param [in] d is either a numpy array or a float that is Terrestrial Time
+    @param [in] d is either a numpy array or a number that is Terrestrial Time
     expressed as an MJD
 
     @param [out] the equation of equinoxes in radians.

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -5,7 +5,6 @@ of palpy methods, or that have no dependence on palpy at all
 
 import numpy as np
 import palpy
-from collections import OrderedDict
 
 __all__ = ["_galacticFromEquatorial", "galacticFromEquatorial",
            "_equatorialFromGalactic", "equatorialFromGalactic",
@@ -44,7 +43,6 @@ def calcLmstLast(mjd, longRad):
         if len(longRad) != len(mjd):
             raise RuntimeError("in calcLmstLast mjd and longRad have different lengths")
 
-
     valid_type = False
     if isinstance(mjd, np.ndarray) and isinstance(longRad, np.ndarray):
         valid_type = True
@@ -59,7 +57,7 @@ def calcLmstLast(mjd, longRad):
               "mjd as a numpy array and longRad as a float\n" \
               "mjd as a float and longRad as a float\n" \
               "You gave mjd: %s\n" % type(mjd) \
-             + "and longRad: %s\n" % type(longRad)
+              + "and longRad: %s\n" % type(longRad)
 
         raise RuntimeError(msg)
 
@@ -67,7 +65,7 @@ def calcLmstLast(mjd, longRad):
     longDeg0 %= 360.0
 
     if longRadIsArray:
-        longDeg = np.where(longDeg0>180.0, longDeg0-360.0, longDeg0)
+        longDeg = np.where(longDeg0 > 180.0, longDeg0 - 360.0, longDeg0)
     else:
         if longDeg0 > 180.:
             longDeg = longDeg0-360.
@@ -189,9 +187,7 @@ def cartesianFromSpherical(longitude, latitude):
         raise RuntimeError("longitude and latitude must both be either numpy arrays or a floats")
 
     cosDec = np.cos(latitude)
-    return np.array([np.cos(longitude)*cosDec,
-                      np.sin(longitude)*cosDec,
-                      np.sin(latitude)]).transpose()
+    return np.array([np.cos(longitude)*cosDec, np.sin(longitude)*cosDec, np.sin(latitude)]).transpose()
 
 
 def sphericalFromCartesian(xyz):
@@ -209,12 +205,12 @@ def sphericalFromCartesian(xyz):
     if not isinstance(xyz, np.ndarray):
         raise RuntimeError("you need to pass a numpy array to sphericalFromCartesian")
 
-    if len(xyz.shape)>1:
-        rad = np.sqrt(np.power(xyz,2).sum(axis=1))
-        longitude = np.arctan2( xyz[:,1], xyz[:,0])
-        latitude = np.arcsin( xyz[:,2] / rad)
+    if len(xyz.shape) > 1:
+        rad = np.sqrt(np.power(xyz, 2).sum(axis=1))
+        longitude = np.arctan2(xyz[:, 1], xyz[:, 0])
+        latitude = np.arcsin(xyz[:, 2]/rad)
     else:
-        rad = np.sqrt(np.dot(xyz,xyz))
+        rad = np.sqrt(np.dot(xyz, xyz))
         longitude = np.arctan2(xyz[1], xyz[0])
         latitude = np.arcsin(xyz[2]/rad)
 
@@ -231,29 +227,28 @@ def rotationMatrixFromVectors(v1, v2):
 
     '''
 
-    if np.abs(np.sqrt(np.dot(v1,v1))-1.0) > 0.01:
+    if np.abs(np.sqrt(np.dot(v1, v1)) - 1.0) > 0.01:
         raise RuntimeError("v1 in rotationMatrixFromVectors is not a unit vector")
 
-    if np.abs(np.sqrt(np.dot(v2,v2))-1.0) > 0.01:
+    if np.abs(np.sqrt(np.dot(v2, v2)) - 1.0) > 0.01:
         raise RuntimeError("v2 in rotationMatrixFromVectors is not a unit vector")
 
     # Calculate the axis of rotation by the cross product of v1 and v2
-    cross = np.cross(v1,v2)
-    cross = cross / np.sqrt(np.dot(cross,cross))
+    cross = np.cross(v1, v2)
+    cross = cross/np.sqrt(np.dot(cross, cross))
 
     # calculate the angle of rotation via dot product
-    angle  = np.arccos(np.dot(v1,v2))
+    angle = np.arccos(np.dot(v1, v2))
     sinDot = np.sin(angle)
     cosDot = np.cos(angle)
 
     # calculate the corresponding rotation matrix
     # http://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle
-    rot = [[cosDot + cross[0]*cross[0]*(1-cosDot), -cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1], \
-            cross[1]*sinDot + (1-cosDot)*cross[0]*cross[2]],\
-            [cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1], cosDot + (1-cosDot)*cross[1]*cross[1], \
-            -cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2]], \
-            [-cross[1]*sinDot+(1-cosDot)*cross[0]*cross[2], \
-            cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2], \
+    rot = [[cosDot + cross[0]*cross[0]*(1-cosDot), -cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1],
+            cross[1]*sinDot + (1-cosDot)*cross[0]*cross[2]],
+           [cross[2]*sinDot+(1-cosDot)*cross[0]*cross[1], cosDot + (1-cosDot)*cross[1]*cross[1],
+            -cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2]],
+           [-cross[1]*sinDot+(1-cosDot)*cross[0]*cross[2], cross[0]*sinDot+(1-cosDot)*cross[1]*cross[2],
             cosDot + (1-cosDot)*(cross[2]*cross[2])]]
 
     return rot

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -54,10 +54,14 @@ def calcLmstLast(mjd, longRad):
         valid_type = True
 
     if not valid_type:
-        raise RuntimeError("Valid input types for calcLmstLast are:\n"
-                           "mjd and longRad as numpy arrays of the same length\n"
-                           "mjd as a numpy array and longRad as a float\n"
-                           "mjd as a float and longRad as a float\n")
+        msg = "Valid input types for calcLmstLast are:\n" \
+              "mjd and longRad as numpy arrays of the same length\n" \
+              "mjd as a numpy array and longRad as a float\n" \
+              "mjd as a float and longRad as a float\n" \
+              "You gave mjd: %s\n" % type(mjd) \
+             + "and longRad: %s\n" % type(longRad)
+
+        raise RuntimeError(msg)
 
     longDeg0 = np.degrees(longRad)
     longDeg0 %= 360.0

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -24,9 +24,9 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     observers actually see, rather than the idealized, above-the-atmosphere
     coordinates represented by the ICRS.
 
-    @param [in] ra_in is in degrees (ICRS).  Can be either a numpy array or a float.
+    @param [in] ra_in is in degrees (ICRS).  Can be either a numpy array or a number.
 
-    @param [in] dec_in is in degrees (ICRS).  Can be either a numpy array or a float.
+    @param [in] dec_in is in degrees (ICRS).  Can be either a numpy array or a number.
 
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
@@ -58,9 +58,9 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     observers actually see, rather than the idealized, above-the-atmosphere
     coordinates represented by the ICRS.
 
-    @param [in] ra_in is in radians (ICRS).  Can be either a numpy array or a float.
+    @param [in] ra_in is in radians (ICRS).  Can be either a numpy array or a number.
 
-    @param [in] dec_in is in radians (ICRS).  Can be either a numpy array or a float.
+    @param [in] dec_in is in radians (ICRS).  Can be either a numpy array or a number.
 
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
@@ -148,10 +148,10 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
 def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
     @param [in] xPupil -- pupil coordinates in radians.
-    Can be a numpy array or a float.
+    Can be a numpy array or a number.
 
     @param [in] yPupil -- pupil coordinates in radians.
-    Can be a numpy array or a float.
+    Can be a numpy array or a number.
 
     @param [in] obs_metadata -- an instantiation of ObservationMetaData characterizing
     the state of the telescope
@@ -173,10 +173,10 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
 def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
     @param [in] xPupil -- pupil coordinates in radians.
-    Can be a numpy array or a float.
+    Can be a numpy array or a number.
 
     @param [in] yPupil -- pupil coordinates in radians.
-    Can be a numpy array or a float.
+    Can be a numpy array or a number.
 
     @param [in] obs_metadata -- an instantiation of ObservationMetaData characterizing
     the state of the telescope

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -147,9 +147,11 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
 
 def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
-    @param [in] xPupil -- pupil coordinates in radians
+    @param [in] xPupil -- pupil coordinates in radians.
+    Can be a numpy array or a float.
 
-    @param [in] yPupil -- pupil coordinates in radians
+    @param [in] yPupil -- pupil coordinates in radians.
+    Can be a numpy array or a float.
 
     @param [in] obs_metadata -- an instantiation of ObservationMetaData characterizing
     the state of the telescope
@@ -169,9 +171,11 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
 
 def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
-    @param [in] xPupil -- pupil coordinates in radians
+    @param [in] xPupil -- pupil coordinates in radians.
+    Can be a numpy array or a float.
 
-    @param [in] yPupil -- pupil coordinates in radians
+    @param [in] yPupil -- pupil coordinates in radians.
+    Can be a numpy array or a float.
 
     @param [in] obs_metadata -- an instantiation of ObservationMetaData characterizing
     the state of the telescope
@@ -182,6 +186,8 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     @param [out] a 2-D numpy array in which the first row is RA and the second
     row is Dec (both in radians; both in the International Celestial Reference System)
     """
+
+    are_arrays = _validate_inputs([xPupil, yPupil], "raDecFromPupilCoords")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call raDecFromPupilCoords without obs_metadata")
@@ -201,10 +207,6 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
         raise RuntimeError("Cannot calculate x_pupil, y_pupil without mjd " + \
                            "in obs_metadata")
 
-    if len(xPupil)!=len(yPupil):
-        raise RuntimeError("You passed %d RAs but %d Decs into raDecFromPupilCoords" % \
-                           (len(raObj), len(decObj)))
-
     ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
                                                   obs_metadata._pointingDec,
                                                   obs_metadata=obs_metadata,
@@ -222,7 +224,10 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     # x_g and y_g are now the x and y coordinates
     # can now use the PALPY method palDtp2s to convert to RA, Dec.
 
-    raObs, decObs = palpy.dtp2sVector(x_g, y_g, ra_pointing, dec_pointing)
+    if are_arrays:
+        raObs, decObs = palpy.dtp2sVector(x_g, y_g, ra_pointing, dec_pointing)
+    else:
+        raObs, decObs = palpy.dtp2s(x_g, y_g, ra_pointing, dec_pointing)
 
     ra_icrs, dec_icrs = _icrsFromObserved(raObs, decObs,
                                           obs_metadata=obs_metadata,

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -6,7 +6,7 @@ __all__ = ["_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
            "_raDecFromPupilCoords", "raDecFromPupilCoords"]
 
 
-def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
+def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -32,9 +32,7 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
 
-    @param [in] epoch is the epoch of mean ra and dec in julian years (optional; if not
-    provided, this method will try to get it from the db_obj member variable, assuming this
-    method is part of an InstanceCatalog)
+    @param [in] epoch is the epoch of mean ra and dec in julian years (default=2000.0)
 
     @param [out] returns a numpy array whose first row is the x coordinate on the pupil in
     radians and whose second row is the y coordinate in radians
@@ -44,7 +42,7 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
                                  obs_metadata=obs_metadata, epoch=epoch)
 
 
-def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
+def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -70,9 +68,7 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=None):
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
 
-    @param [in] epoch is the epoch of mean ra and dec in julian years (optional; if not
-    provided, this method will try to get it from the db_obj member variable, assuming this
-    method is part of an InstanceCatalog)
+    @param [in] epoch is the epoch of mean ra and dec in julian years (default=2000.0)
 
     @param [out] returns a numpy array whose first row is the x coordinate on the pupil in
     radians and whose second row is the y coordinate in radians

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -97,11 +97,7 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
                                                   obs_metadata._pointingDec,
                                                   obs_metadata=obs_metadata,
-                                                  epoch=2000.0, includeRefraction=True)
-                                                  # epoch is set to 2000.0 here, because that
-                                                  # is the epoch of ObservationMetaData
-                                                  # RA, Dec, which is what we are dealing with
-                                                  # in this line of code.
+                                                  epoch=epoch, includeRefraction=True)
 
     #palpy.ds2tp performs the gnomonic projection on ra_in and dec_in
     #with a tangent point at (pointingRA, pointingDec)

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -84,7 +84,7 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
         raise RuntimeError("Cannot call pupilCoordsFromRaDec; epoch is None")
 
     if obs_metadata.rotSkyPos is None:
-        #there is no observation meta data on which to base astrometry
+        # there is no observation meta data on which to base astrometry
         raise RuntimeError("Cannot calculate [x,y]_focal_nominal without obs_metadata.rotSkyPos")
 
     if obs_metadata.pointingRA is None or obs_metadata.pointingDec is None:
@@ -100,8 +100,8 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
                                                   obs_metadata=obs_metadata,
                                                   epoch=epoch, includeRefraction=True)
 
-    #palpy.ds2tp performs the gnomonic projection on ra_in and dec_in
-    #with a tangent point at (pointingRA, pointingDec)
+    # palpy.ds2tp performs the gnomonic projection on ra_in and dec_in
+    # with a tangent point at (pointingRA, pointingDec)
     #
     if not are_arrays:
         try:
@@ -127,7 +127,6 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
                 y.append(yy)
             x = np.array(x)
             y = np.array(y)
-
 
     # The extra negative sign on x_out comes from the following:
     # The Gnomonic projection as calculated by palpy is such that,
@@ -164,8 +163,9 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     row is Dec (both in degrees; both in the International Celestial Reference System)
     """
 
-    output = _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=obs_metadata,
-                                               epoch=epoch)
+    output = _raDecFromPupilCoords(xPupil, yPupil,
+                                   obs_metadata=obs_metadata,
+                                   epoch=epoch)
 
     return np.degrees(output)
 
@@ -188,8 +188,7 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     row is Dec (both in radians; both in the International Celestial Reference System)
     """
 
-    are_arrays = _validate_inputs([xPupil, yPupil], ['xPupil', 'yPupil'],
-                                 "raDecFromPupilCoords")
+    are_arrays = _validate_inputs([xPupil, yPupil], ['xPupil', 'yPupil'], "raDecFromPupilCoords")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call raDecFromPupilCoords without obs_metadata")
@@ -198,15 +197,15 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
         raise RuntimeError("Cannot call raDecFromPupilCoords; epoch is None")
 
     if obs_metadata.rotSkyPos is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoords without rotSkyPos " + \
+        raise RuntimeError("Cannot call raDecFromPupilCoords without rotSkyPos " +
                            "in obs_metadata")
 
     if obs_metadata.pointingRA is None or obs_metadata.pointingDec is None:
-        raise RuntimeError("Cannot call raDecFromPupilCoords "+ \
-                          "without pointingRA, pointingDec in obs_metadata")
+        raise RuntimeError("Cannot call raDecFromPupilCoords " +
+                           "without pointingRA, pointingDec in obs_metadata")
 
     if obs_metadata.mjd is None:
-        raise RuntimeError("Cannot calculate x_pupil, y_pupil without mjd " + \
+        raise RuntimeError("Cannot calculate x_pupil, y_pupil without mjd " +
                            "in obs_metadata")
 
     ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
@@ -214,8 +213,8 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
                                                   obs_metadata=obs_metadata,
                                                   epoch=epoch, includeRefraction=True)
 
-    #This is the same as theta in pupilCoordsFromRaDec, except without the minus sign.
-    #This is because we will be reversing the rotation performed in that other method.
+    # This is the same as theta in pupilCoordsFromRaDec, except without the minus sign.
+    # This is because we will be reversing the rotation performed in that other method.
     theta = -1.0*obs_metadata._rotSkyPos
 
     x_g = xPupil*np.cos(theta) - yPupil*np.sin(theta)

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -71,7 +71,8 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     radians and whose second row is the y coordinate in radians
     """
 
-    are_arrays = _validate_inputs([ra_in, dec_in], "pupilCoordsFromRaDec")
+    are_arrays = _validate_inputs([ra_in, dec_in], ['ra_in', 'dec_in'],
+                                  "pupilCoordsFromRaDec")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call pupilCoordsFromRaDec without obs_metadata")
@@ -187,7 +188,8 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     row is Dec (both in radians; both in the International Celestial Reference System)
     """
 
-    are_arrays = _validate_inputs([xPupil, yPupil], "raDecFromPupilCoords")
+    are_arrays = _validate_inputs([xPupil, yPupil], ['xPupil', 'yPupil'],
+                                 "raDecFromPupilCoords")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call raDecFromPupilCoords without obs_metadata")

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -145,7 +145,7 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     return np.array([x_out, y_out])
 
 
-def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
+def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
     @param [in] xPupil -- pupil coordinates in radians
 
@@ -155,7 +155,7 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     the state of the telescope
 
     @param [in] epoch -- julian epoch of the mean equinox used for the coordinate
-    transformations (in years)
+    transformations (in years; defaults to 2000)
 
     @param [out] a 2-D numpy array in which the first row is RA and the second
     row is Dec (both in degrees; both in the International Celestial Reference System)
@@ -167,7 +167,7 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     return np.degrees(output)
 
 
-def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
+def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     """
     @param [in] xPupil -- pupil coordinates in radians
 
@@ -177,7 +177,7 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     the state of the telescope
 
     @param [in] epoch -- julian epoch of the mean equinox used for the coordinate
-    transformations (in years)
+    transformations (in years; defaults to 2000)
 
     @param [out] a 2-D numpy array in which the first row is RA and the second
     row is Dec (both in radians; both in the International Celestial Reference System)
@@ -205,13 +205,10 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
         raise RuntimeError("You passed %d RAs but %d Decs into raDecFromPupilCoords" % \
                            (len(raObj), len(decObj)))
 
-    ra_pointing_temp, dec_pointing_temp = _observedFromICRS(np.array([obs_metadata._pointingRA]),
-                                                            np.array([obs_metadata._pointingDec]),
-                                                            obs_metadata=obs_metadata,
-                                                            epoch=2000.0, includeRefraction=True)
-
-    ra_pointing = ra_pointing_temp[0]
-    dec_pointing = dec_pointing_temp[0]
+    ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
+                                                  obs_metadata._pointingDec,
+                                                  obs_metadata=obs_metadata,
+                                                  epoch=epoch, includeRefraction=True)
 
     #This is the same as theta in pupilCoordsFromRaDec, except without the minus sign.
     #This is because we will be reversing the rotation performed in that other method.
@@ -228,6 +225,7 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=None):
     raObs, decObs = palpy.dtp2sVector(x_g, y_g, ra_pointing, dec_pointing)
 
     ra_icrs, dec_icrs = _icrsFromObserved(raObs, decObs,
-                                          obs_metadata=obs_metadata, epoch=2000.0, includeRefraction=True)
+                                          obs_metadata=obs_metadata,
+                                          epoch=epoch, includeRefraction=True)
 
     return np.array([ra_icrs, dec_icrs])

--- a/python/lsst/sims/utils/ObservationMetaData.py
+++ b/python/lsst/sims/utils/ObservationMetaData.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import inspect
 from .SpatialBounds import SpatialBounds
 from lsst.sims.utils import ModifiedJulianDate
@@ -114,22 +114,22 @@ class ObservationMetaData(object):
             self._mjd = None
 
         if rotSkyPos is not None:
-            self._rotSkyPos = numpy.radians(rotSkyPos)
+            self._rotSkyPos = np.radians(rotSkyPos)
         else:
             self._rotSkyPos = None
 
         if pointingRA is not None:
-            self._pointingRA = numpy.radians(pointingRA)
+            self._pointingRA = np.radians(pointingRA)
         else:
             self._pointingRA = None
 
         if pointingDec is not None:
-            self._pointingDec = numpy.radians(pointingDec)
+            self._pointingDec = np.radians(pointingDec)
         else:
             self._pointingDec = None
 
         if boundLength is not None:
-            self._boundLength = numpy.radians(boundLength)
+            self._boundLength = np.radians(boundLength)
         else:
             self._boundLength = None
 
@@ -333,7 +333,7 @@ class ObservationMetaData(object):
         (in the International Celestial Reference System).
         """
         if self._pointingRA is not None:
-            return numpy.degrees(self._pointingRA)
+            return np.degrees(self._pointingRA)
         else:
             return None
 
@@ -344,7 +344,7 @@ class ObservationMetaData(object):
                 raise RuntimeError('WARNING overwriting pointingRA ' +
                                    'which was set by phoSimMetaData')
 
-        self._pointingRA = numpy.radians(value)
+        self._pointingRA = np.radians(value)
         self._buildBounds()
 
     @property
@@ -354,7 +354,7 @@ class ObservationMetaData(object):
         (in the International Celestial Reference System).
         """
         if self._pointingDec is not None:
-            return numpy.degrees(self._pointingDec)
+            return np.degrees(self._pointingDec)
         else:
             return None
 
@@ -365,7 +365,7 @@ class ObservationMetaData(object):
                 raise RuntimeError('WARNING overwriting pointingDec ' +
                                    'which was set by phoSimMetaData')
 
-        self._pointingDec = numpy.radians(value)
+        self._pointingDec = np.radians(value)
         self._buildBounds()
 
     @property
@@ -384,11 +384,11 @@ class ObservationMetaData(object):
         if self._boundLength is None:
             return None
 
-        return numpy.degrees(self._boundLength)
+        return np.degrees(self._boundLength)
 
     @boundLength.setter
     def boundLength(self, value):
-        self._boundLength = numpy.radians(value)
+        self._boundLength = np.radians(value)
         self._buildBounds()
 
     @property
@@ -420,7 +420,7 @@ class ObservationMetaData(object):
         It is a parameter you should get from OpSim.
         """
         if self._rotSkyPos is not None:
-            return numpy.degrees(self._rotSkyPos)
+            return np.degrees(self._rotSkyPos)
         else:
             return None
 
@@ -431,7 +431,7 @@ class ObservationMetaData(object):
                 raise RuntimeError('WARNING overwriting rotSkyPos ' +
                                    'which was set by phoSimMetaData')
 
-        self._rotSkyPos = numpy.radians(value)
+        self._rotSkyPos = np.radians(value)
 
 
     @property

--- a/python/lsst/sims/utils/ObservationMetaData.py
+++ b/python/lsst/sims/utils/ObservationMetaData.py
@@ -1,10 +1,10 @@
 import numpy as np
-import inspect
 from .SpatialBounds import SpatialBounds
 from lsst.sims.utils import ModifiedJulianDate
 from lsst.sims.utils import Site
 
 __all__ = ["ObservationMetaData"]
+
 
 class ObservationMetaData(object):
     """Observation Metadata
@@ -149,11 +149,10 @@ class ObservationMetaData(object):
         # somehow in sync).
         self._seeing = self._assignDictKeyedToBandpass(seeing, 'seeing')
 
-        #this should be done after phoSimMetaData is assigned, just in case
-        #self._assignPhoSimMetadata overwrites pointingRA/Dec
+        # this should be done after phoSimMetaData is assigned, just in case
+        # self._assignPhoSimMetadata overwrites pointingRA/Dec
         if self._bounds is None:
             self._buildBounds()
-
 
     @property
     def summary(self):
@@ -214,20 +213,19 @@ class ObservationMetaData(object):
                 inputIsList = True
 
             if bandpassIsList and not inputIsList:
-                raise RuntimeError('You passed a list of bandpass names' + \
+                raise RuntimeError('You passed a list of bandpass names' +
                                    'but did not pass a list of %s to ObservationMetaData' % inputName)
 
             if inputIsList and not bandpassIsList:
-                raise RuntimeError('You passed a list of %s ' % inputName + \
-                                    'but did not pass a list of bandpass names to ObservationMetaData')
-
+                raise RuntimeError('You passed a list of %s ' % inputName +
+                                   'but did not pass a list of bandpass names to ObservationMetaData')
 
             if inputIsList:
                 if len(inputValue) != len(self._bandpass):
-                    raise RuntimeError('The list of %s you passed to ObservationMetaData ' % inputName + \
+                    raise RuntimeError('The list of %s you passed to ObservationMetaData ' % inputName +
                                        'has a different length than the list of bandpass names you passed')
 
-            #now build the dict
+            # now build the dict
             if bandpassIsList:
                 if len(inputValue) != len(self._bandpass):
                     raise RuntimeError('In ObservationMetaData you tried to assign bandpass ' +
@@ -237,10 +235,9 @@ class ObservationMetaData(object):
                 for b, m in zip(self._bandpass, inputValue):
                     outputDict[b] = m
             else:
-                outputDict = {self._bandpass:inputValue}
+                outputDict = {self._bandpass: inputValue}
 
             return outputDict
-
 
     def _buildBounds(self):
         """
@@ -262,7 +259,6 @@ class ObservationMetaData(object):
         self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._pointingRA, self._pointingDec,
                                                       self._boundLength)
 
-
     def _assignPhoSimMetaData(self, metaData):
         """
         Assign the dict metaData to be the associated phoSimMetaData dict of this object.
@@ -276,10 +272,11 @@ class ObservationMetaData(object):
         self._phoSimMetaData = metaData
 
         if self._phoSimMetaData is not None:
-            #overwrite member variables with values from the phoSimMetaData
+            # overwrite member variables with values from the phoSimMetaData
             if 'Opsim_expmjd' in self._phoSimMetaData:
                 if self._mjd is not None:
-                    raise RuntimeError('WARNING in ObservationMetaData trying to overwrite mjd with phoSimMetaData')
+                    raise RuntimeError('WARNING in ObservationMetaData trying to '
+                                       'overwrite mjd with phoSimMetaData')
 
                 self._mjd = ModifiedJulianDate(TAI=self._phoSimMetaData['Opsim_expmjd'][0])
 
@@ -289,7 +286,6 @@ class ObservationMetaData(object):
                                        'with phoSimMetaData')
 
                 self._rotSkyPos = self._phoSimMetaData['Opsim_rotskypos'][0]
-
 
             if 'Opsim_filter' in self._phoSimMetaData:
                 if self._bandpass is not None:
@@ -425,14 +421,13 @@ class ObservationMetaData(object):
             return None
 
     @rotSkyPos.setter
-    def rotSkyPos(self,value):
+    def rotSkyPos(self, value):
         if self._phoSimMetaData is not None:
             if 'Opsim_rotskypos' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting rotSkyPos ' +
                                    'which was set by phoSimMetaData')
 
         self._rotSkyPos = np.radians(value)
-
 
     @property
     def m5(self):
@@ -446,7 +441,6 @@ class ObservationMetaData(object):
     @m5.setter
     def m5(self, value):
         self._m5 = self._assignDictKeyedToBandpass(value, 'm5')
-
 
     @property
     def seeing(self):
@@ -464,7 +458,6 @@ class ObservationMetaData(object):
                                    'which was set by phoSimMetaData')
 
         self._seeing = self._assignDictKeyedToBandpass(value, 'seeing')
-
 
     @property
     def site(self):
@@ -503,7 +496,6 @@ class ObservationMetaData(object):
         else:
             raise RuntimeError("You can only set mjd to either a float or a ModifiedJulianDate")
 
-
     @property
     def bandpass(self):
         """
@@ -540,7 +532,6 @@ class ObservationMetaData(object):
             if 'Opsim_rawseeing' in self._phoSimMetaData:
                 raise RuntimeError('WARNING overwriting seeing ' +
                                    'which was set by phoSimMetaData')
-
 
         self._bandpass = bandpassName
         self._m5 = self._assignDictKeyedToBandpass(m5, 'm5')

--- a/python/lsst/sims/utils/WcsUtils.py
+++ b/python/lsst/sims/utils/WcsUtils.py
@@ -5,6 +5,7 @@ __all__ = ["_nativeLonLatFromPointing", "_lonLatFromNativeLonLat",
            "_nativeLonLatFromRaDec", "_raDecFromNativeLonLat",
            "nativeLonLatFromRaDec", "raDecFromNativeLonLat"]
 
+
 def _nativeLonLatFromPointing(lon, lat, lonPointing, latPointing):
     """
     Convert the longitude and latitude of a point into `native'
@@ -43,20 +44,13 @@ def _nativeLonLatFromPointing(lon, lat, lonPointing, latPointing):
     alpha = latPointing - 0.5*np.pi
     beta = lonPointing
 
-    ca=np.cos(alpha)
-    sa=np.sin(alpha)
-    cb=np.cos(beta)
-    sb=np.sin(beta)
+    ca = np.cos(alpha)
+    sa = np.sin(alpha)
+    cb = np.cos(beta)
+    sb = np.sin(beta)
 
-    v2 = np.dot(np.array([
-                          [1.0, 0.0, 0.0],
-                          [0.0, ca, sa],
-                          [0.0, -1.0*sa, ca]
-                          ]),
-                   np.dot(np.array([[cb, sb, 0.0],
-                                    [-sb, cb, 0.0],
-                                    [0.0, 0.0, 1.0]
-                                    ]), np.array([x,y,z])))
+    v2 = np.dot(np.array([[1.0, 0.0, 0.0], [0.0, ca, sa], [0.0, -1.0*sa, ca]]),
+                np.dot(np.array([[cb, sb, 0.0], [-sb, cb, 0.0], [0.0, 0.0, 1.0]]), np.array([x, y, z])))
 
     cc = np.sqrt(v2[0]*v2[0]+v2[1]*v2[1])
     latOut = np.arctan2(v2[2], cc)
@@ -67,12 +61,13 @@ def _nativeLonLatFromPointing(lon, lat, lonPointing, latPointing):
     # control for _y=1.0, -1.0 but actually being stored as just outside
     # the bounds of -1.0<=_y<=1.0 because of floating point error
     if hasattr(_ra_raw, '__len__'):
-        _ra = np.array([rr if not np.isnan(rr) \
-                           else 0.5*np.pi*(1.0-np.sign(yy)) \
-                           for rr, yy in zip(_ra_raw, _y)])
+        _ra = np.array([rr
+                        if not np.isnan(rr)
+                        else 0.5*np.pi*(1.0-np.sign(yy))
+                        for rr, yy in zip(_ra_raw, _y)])
     else:
         if np.isnan(_ra_raw):
-            if np.sign(_y)<0.0:
+            if np.sign(_y) < 0.0:
                 _ra = np.pi
             else:
                 _ra = 0.0
@@ -84,16 +79,18 @@ def _nativeLonLatFromPointing(lon, lat, lonPointing, latPointing):
     if type(_ra) is np.float64:
         if np.isnan(_ra):
             lonOut = 0.0
-        elif (np.abs(_x)>1.0e-9 and np.sign(_x)!=np.sign(v2[0])) \
-             or (np.abs(_y)>1.0e-9 and np.sign(_y)!=np.sign(v2[1])):
+        elif (np.abs(_x) > 1.0e-9 and np.sign(_x) != np.sign(v2[0])) or \
+             (np.abs(_y) > 1.0e-9 and np.sign(_y) != np.sign(v2[1])):
+
             lonOut = 2.0*np.pi-_ra
         else:
             lonOut = _ra
     else:
-        _lonOut = [2.0*np.pi-rr if (np.abs(xx)>1.0e-9 and np.sign(xx)!=np.sign(v2_0)) \
-                                   or (np.abs(yy)>1.0e-9 and np.sign(yy)!=np.sign(v2_1)) \
-                                   else rr \
-                                   for rr, xx, yy, v2_0, v2_1 in zip(_ra, _x, _y, v2[0], v2[1])]
+        _lonOut = [2.0*np.pi-rr
+                   if (np.abs(xx) > 1.0e-9 and np.sign(xx) != np.sign(v2_0))
+                   or (np.abs(yy) > 1.0e-9 and np.sign(yy) != np.sign(v2_1))
+                   else rr
+                   for rr, xx, yy, v2_0, v2_1 in zip(_ra, _x, _y, v2[0], v2[1])]
 
         lonOut = np.array([0.0 if np.isnan(ll) else ll for ll in _lonOut])
 
@@ -130,21 +127,13 @@ def _lonLatFromNativeLonLat(nativeLon, nativeLat, lonPointing, latPointing):
     alpha = 0.5*np.pi - latPointing
     beta = lonPointing
 
-    ca=np.cos(alpha)
-    sa=np.sin(alpha)
-    cb=np.cos(beta)
-    sb=np.sin(beta)
+    ca = np.cos(alpha)
+    sa = np.sin(alpha)
+    cb = np.cos(beta)
+    sb = np.sin(beta)
 
-    v2 = np.dot(np.array([[cb, -1.0*sb, 0.0],
-                          [sb, cb, 0.0],
-                          [0.0, 0.0, 1.0]
-                          ]),
-                                np.dot(np.array([[1.0, 0.0, 0.0],
-                                                 [0.0, ca, sa],
-                                                 [0.0, -1.0*sa, ca]
-                                ]),
-                                np.array([x,y,z])))
-
+    v2 = np.dot(np.array([[cb, -1.0*sb, 0.0], [sb, cb, 0.0], [0.0, 0.0, 1.0]]),
+                np.dot(np.array([[1.0, 0.0, 0.0], [0.0, ca, sa], [0.0, -1.0*sa, ca]]), np.array([x, y, z])))
 
     cc = np.sqrt(v2[0]*v2[0]+v2[1]*v2[1])
     latOut = np.arctan2(v2[2], cc)
@@ -156,16 +145,18 @@ def _lonLatFromNativeLonLat(nativeLon, nativeLat, lonPointing, latPointing):
     if type(_lonOut) is np.float64:
         if np.isnan(_lonOut):
             lonOut = 0.0
-        elif (np.abs(_x)>1.0e-9 and np.sign(_x)!=np.sign(v2[0])) \
-             or (np.abs(_y)>1.0e-9 and np.sign(_y)!=np.sign(v2[1])):
+        elif (np.abs(_x) > 1.0e-9 and np.sign(_x) != np.sign(v2[0])) or \
+             (np.abs(_y) > 1.0e-9 and np.sign(_y) != np.sign(v2[1])):
+
             lonOut = 2.0*np.pi-_lonOut
         else:
             lonOut = _lonOut
     else:
-        _lonOut = [2.0*np.pi-rr if (np.abs(xx)>1.0e-9 and np.sign(xx)!=np.sign(v2_0)) \
-                                  or (np.abs(yy)>1.0e-9 and np.sign(yy)!=np.sign(v2_1)) \
-                                  else rr \
-                                  for rr, xx, yy, v2_0, v2_1 in zip(_lonOut, _x, _y, v2[0], v2[1])]
+        _lonOut = [2.0*np.pi-rr
+                   if (np.abs(xx) > 1.0e-9 and np.sign(xx) != np.sign(v2_0))
+                   or (np.abs(yy) > 1.0e-9 and np.sign(yy) != np.sign(v2_1))
+                   else rr
+                   for rr, xx, yy, v2_0, v2_1 in zip(_lonOut, _x, _y, v2[0], v2[1])]
 
         lonOut = np.array([0.0 if np.isnan(rr) else rr for rr in _lonOut])
 
@@ -207,9 +198,9 @@ def _nativeLonLatFromRaDec(ra_in, dec_in, obs_metadata):
                                 includeRefraction=True)
 
     raPointing, decPointing = _observedFromICRS(obs_metadata._pointingRA,
-                                               obs_metadata._pointingDec,
-                                               obs_metadata=obs_metadata, epoch=2000.0,
-                                               includeRefraction=True)
+                                                obs_metadata._pointingDec,
+                                                obs_metadata=obs_metadata, epoch=2000.0,
+                                                includeRefraction=True)
 
     return _nativeLonLatFromPointing(ra, dec, raPointing, decPointing)
 
@@ -282,7 +273,6 @@ def _raDecFromNativeLonLat(lon, lat, obs_metadata):
                                                 includeRefraction=True)
 
     raObs, decObs = _lonLatFromNativeLonLat(lon, lat, raPointing, decPointing)
-
 
     # convert from observed geocentric coordinates to International Celestial Reference System
     # coordinates

--- a/python/lsst/sims/utils/WcsUtils.py
+++ b/python/lsst/sims/utils/WcsUtils.py
@@ -202,25 +202,14 @@ def _nativeLonLatFromRaDec(ra_in, dec_in, obs_metadata):
     @param [out] latOut is the native latitude in radians
     """
 
-    if not hasattr(ra_in, '__len__'):
-        ra_temp, dec_temp = _observedFromICRS(np.array([ra_in]), np.array([dec_in]),
-                                              obs_metadata=obs_metadata, epoch=2000.0,
-                                              includeRefraction=True)
+    ra, dec = _observedFromICRS(ra_in, dec_in,
+                                obs_metadata=obs_metadata, epoch=2000.0,
+                                includeRefraction=True)
 
-        ra = ra_temp[0]
-        dec = dec_temp[0]
-    else:
-        ra, dec = _observedFromICRS(ra_in, dec_in,
-                                    obs_metadata=obs_metadata, epoch=2000.0,
-                                    includeRefraction=True)
-
-    ra_temp, dec_temp = _observedFromICRS(np.array([obs_metadata._pointingRA]),
-                                          np.array([obs_metadata._pointingDec]),
-                                          obs_metadata=obs_metadata, epoch=2000.0,
-                                          includeRefraction=True)
-
-    raPointing = ra_temp[0]
-    decPointing = dec_temp[0]
+    raPointing, decPointing = _observedFromICRS(obs_metadata._pointingRA,
+                                               obs_metadata._pointingDec,
+                                               obs_metadata=obs_metadata, epoch=2000.0,
+                                               includeRefraction=True)
 
     return _nativeLonLatFromPointing(ra, dec, raPointing, decPointing)
 
@@ -287,13 +276,10 @@ def _raDecFromNativeLonLat(lon, lat, obs_metadata):
     than 45 degrees and zenith distances of less than 75 degrees.
     """
 
-    ra_temp, dec_temp = _observedFromICRS(np.array([obs_metadata._pointingRA]),
-                                          np.array([obs_metadata._pointingDec]),
-                                          obs_metadata=obs_metadata, epoch=2000.0,
-                                          includeRefraction=True)
-
-    raPointing = ra_temp[0]
-    decPointing = dec_temp[0]
+    raPointing, decPointing = _observedFromICRS(obs_metadata._pointingRA,
+                                                obs_metadata._pointingDec,
+                                                obs_metadata=obs_metadata, epoch=2000.0,
+                                                includeRefraction=True)
 
     raObs, decObs = _lonLatFromNativeLonLat(lon, lat, raPointing, decPointing)
 
@@ -301,16 +287,8 @@ def _raDecFromNativeLonLat(lon, lat, obs_metadata):
     # convert from observed geocentric coordinates to International Celestial Reference System
     # coordinates
 
-    if hasattr(raObs,'__len__'):
-        raOut, decOut = _icrsFromObserved(raObs, decObs, obs_metadata=obs_metadata,
-                                          epoch=2000.0, includeRefraction=True)
-    else:
-        raOut, decOut = _icrsFromObserved(np.array([raObs]), np.array([decObs]),
-                                          obs_metadata=obs_metadata,
-                                          epoch=2000.0, includeRefraction=True)
-
-    if not hasattr(lon, '__len__'):
-        return raOut[0], decOut[0]
+    raOut, decOut = _icrsFromObserved(raObs, decObs, obs_metadata=obs_metadata,
+                                      epoch=2000.0, includeRefraction=True)
 
     return raOut, decOut
 

--- a/python/lsst/sims/utils/WcsUtils.py
+++ b/python/lsst/sims/utils/WcsUtils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numbers
 from lsst.sims.utils import _observedFromICRS, _icrsFromObserved
 
 __all__ = ["_nativeLonLatFromPointing", "_lonLatFromNativeLonLat",
@@ -76,7 +77,7 @@ def _nativeLonLatFromPointing(lon, lat, lonPointing, latPointing):
 
     _x = -np.sin(_ra)
 
-    if type(_ra) is np.float64:
+    if isinstance(_ra, numbers.Number):
         if np.isnan(_ra):
             lonOut = 0.0
         elif (np.abs(_x) > 1.0e-9 and np.sign(_x) != np.sign(v2[0])) or \
@@ -142,7 +143,7 @@ def _lonLatFromNativeLonLat(nativeLon, nativeLat, lonPointing, latPointing):
     _lonOut = np.arccos(_y)
     _x = -np.sin(_lonOut)
 
-    if type(_lonOut) is np.float64:
+    if isinstance(_lonOut, numbers.Number):
         if np.isnan(_lonOut):
             lonOut = 0.0
         elif (np.abs(_x) > 1.0e-9 and np.sign(_x) != np.sign(v2[0])) or \

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -706,7 +706,8 @@ class astrometryUnitTest(unittest.TestCase):
 
     def test_appGeoFromICRS_inputs(self):
         """
-        Test that appGeoFromICRS behaves as expected when given numpy array inputs
+        Test that appGeoFromICRS behaves as expected when given both numpy
+        array and float inputs.
         """
 
         np.random.seed(83)

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -201,6 +201,19 @@ class astrometryUnitTest(unittest.TestCase):
                 hh = haversine(raS, decS, new_ra, new_dec)
                 self.assertLess(np.abs(arcsecFromRadians(dd-hh)), 5.0)
 
+        # Test passing in numpy arrays of RA, Dec
+        np.random.seed(87)
+        nSamples = 100
+        ra = np.random.random_sample(nSamples)*2.0*np.pi
+        dec = (np.random.random_sample(nSamples)-0.5)*np.pi
+        mjd = 59580.0
+        control_distance = _distanceToSun(ra, dec, mjd)
+        self.assertIsInstance(control_distance, np.ndarray)
+        for ix, (rr, dd) in enumerate(zip(ra, dec)):
+            dd = _distanceToSun(rr, dd, mjd)
+            self.assertIsInstance(dd, np.float)
+            self.assertAlmostEqual(dd, control_distance[ix], 12)
+
 
     def testDistanceToSunDeg(self):
         """

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -761,48 +761,48 @@ class astrometryUnitTest(unittest.TestCase):
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same "
+                         "type, either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(5.0, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same type, "
+                         "either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=5.0, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same type, "
+                         "either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=5.0,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same type, "
+                         "either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=5.0, v_rad=v_rad, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same type, "
+                         "either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=5.0, mjd=mjd)
 
         self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be either "
-                         "floats or numpy arrays")
+                         "The inputs to appGeoFromICRS should all be the same type, "
+                         "either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs[:2], pm_ra=pm_ra, pm_dec=pm_dec,

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -893,7 +893,8 @@ class astrometryUnitTest(unittest.TestCase):
 
     def test_icrsFromObserved(self):
         """
-        Test that _icrsFromObserved really inverts _observedFromAppGeo.
+        Test that _icrsFromObserved really inverts _observedFromICRS and that
+        _appGeoFromObserved really does invert _observedFromAppGeo.
 
         In this case, the method is only reliable at distances of more than
         45 degrees from the sun and at zenith distances less than 70 degrees.
@@ -953,6 +954,17 @@ class astrometryUnitTest(unittest.TestCase):
                                                      ra_app[valid_pts], dec_app[valid_pts]))
 
                         self.assertLess(distance.max(), 0.01)
+
+                        # test that passing arguments in as floats gives consistent
+                        # results
+                        for ix in valid_pts:
+                            ra_f, dec_f = _observedFromAppGeo(ra_in[ix], dec_in[ix],
+                                                              obs_metadata=obs,
+                                                              includeRefraction=includeRefraction)
+                            self.assertIsInstance(ra_f, np.float)
+                            self.assertIsInstance(dec_f, np.float)
+                            dist_f = arcsecFromRadians(pal.dsep(ra_obs[ix], dec_obs[ix], ra_f, dec_f))
+                            self.assertLess(dist_f, 0.0001)
 
 
     def test_icrsFromObservedExceptions(self):

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -560,6 +560,37 @@ class astrometryUnitTest(unittest.TestCase):
             # demand that the two methods agree on the stars' new positions to within one part in 100
 
 
+    def test_applyProperMotion_inputs(self):
+        """
+        Verify that _applyProperMotion handles both floats and numpy arrays as inputs
+        """
+        np.random.seed(7134)
+        nSamples = 100
+        pm_ra = (np.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
+        pm_dec = (np.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
+        px = np.random.random_sample(nSamples)*radiansFromArcsec(1.0)
+        v_rad = np.random.random_sample(nSamples)*200.0
+        mjd = ModifiedJulianDate(TAI=59580.0)
+
+        ra_icrs = np.random.random_sample(nSamples)*2.0*np.pi
+        dec_icrs = (np.random.random_sample(nSamples)-0.5)*np.pi
+
+        ra_arr, dec_arr = _applyProperMotion(ra_icrs, dec_icrs,
+                                             pm_ra, pm_dec, px, v_rad, mjd=mjd)
+
+
+        self.assertIsInstance(ra_arr, np.ndarray)
+        self.assertIsInstance(dec_arr, np.ndarray)
+        for ix, (rr, dd, mura, mudec, xx, vv) in \
+        enumerate(zip(ra_icrs, dec_icrs, pm_ra, pm_dec, px, v_rad)):
+
+            ra_f, dec_f = _applyProperMotion(rr, dd, mura, mudec, xx, vv, mjd=mjd)
+            self.assertIsInstance(ra_f, np.float)
+            self.assertIsInstance(dec_f, np.float)
+            distance = arcsecFromRadians(haversine(ra_f, dec_f, ra_arr[ix], dec_arr[ix]))
+            self.assertLess(distance, 0.000001)
+
+
     def test_appGeoFromICRS(self):
         """
         Test conversion between ICRS RA, Dec and apparent geocentric ICRS.

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -458,7 +458,18 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertRaises(RuntimeError, _applyPrecession, ra, dec)
 
         #just make sure it runs
-        output=_applyPrecession(ra,dec, mjd=ModifiedJulianDate(TAI=57388.0))
+        mjd = ModifiedJulianDate(TAI=57388.0)
+        ra_arr, dec_arr=_applyPrecession(ra, dec, mjd=mjd)
+        self.assertIsInstance(ra_arr, np.ndarray)
+        self.assertIsInstance(dec_arr, np.ndarray)
+
+        # test that passing in floats gie the same results
+        for ix, (rr, dd) in enumerate(zip(ra, dec)):
+            ra_f, dec_f = _applyPrecession(rr, dd, mjd=mjd)
+            self.assertIsInstance(ra_f, np.float)
+            self.assertIsInstance(dec_f, np.float)
+            self.assertAlmostEqual(ra_f, ra_arr[ix], 12)
+            self.assertAlmostEqual(dec_f, dec_arr[ix], 12)
 
 
     def test_applyProperMotion(self):

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -270,7 +270,7 @@ class astrometryUnitTest(unittest.TestCase):
             ra_list = np.random.random_sample(nStars)*2.0*np.pi
             dec_list =(np.random.random_sample(nStars)-0.5)*np.pi
             distance_list = _distanceToSun(ra_list, dec_list, mjd)
-            distance_control = haversine(ra_list, dec_list, np.array([raS]*nStars), np.array([decS]*nStars))
+            distance_control = haversine(ra_list, dec_list, raS, decS)
             np.testing.assert_array_almost_equal(distance_list, distance_control, 5)
 
 

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -442,9 +442,18 @@ class astrometryUnitTest(unittest.TestCase):
         self.assertRaises(RuntimeError, _observedFromICRS, ra, decShort, epoch=2000.0, obs_metadata=dummy)
         self.assertRaises(RuntimeError, _observedFromICRS, raShort, dec, epoch=2000.0, obs_metadata=dummy)
 
-        #test that it actually runs
-        test = _observedFromICRS(ra, dec, obs_metadata=dummy, epoch=2000.0)
+        # test that it actually runs
+        ra_arr, dec_arr = _observedFromICRS(ra, dec, obs_metadata=dummy, epoch=2000.0)
+        self.assertIsInstance(ra_arr, np.ndarray)
+        self.assertIsInstance(dec_arr, np.ndarray)
 
+        # test passing in floats
+        for ix in range(len(ra_arr)):
+            ra_f, dec_f = _observedFromICRS(ra[ix], dec[ix], obs_metadata=dummy, epoch=2000.0)
+            self.assertIsInstance(ra_f, np.float)
+            self.assertIsInstance(dec_f, np.float)
+            self.assertAlmostEqual(ra_f, ra_arr[ix], 12)
+            self.assertAlmostEqual(dec_f, dec_arr[ix], 12)
 
 
     def test_applyPrecession(self):

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -153,7 +153,9 @@ class astrometryUnitTest(unittest.TestCase):
         sun_dec_list = [np.radians(-22.0-47.0/60.0-40.27/3600.0),
                         np.radians(22.0+30.0/60.0+0.73/3600.0)]
 
-        for raS, decS, mjd in zip(sun_ra_list, sun_dec_list, mjd_list):
+        for raS, decS, tai in zip(sun_ra_list, sun_dec_list, mjd_list):
+
+            mjd = ModifiedJulianDate(TAI=tai)
 
             # first, verify that the Sun is where we think it is to within 5 arc seconds
             self.assertLess(arcsecFromRadians(_distanceToSun(raS, decS, mjd)), 5.0)
@@ -206,7 +208,7 @@ class astrometryUnitTest(unittest.TestCase):
         nSamples = 100
         ra = np.random.random_sample(nSamples)*2.0*np.pi
         dec = (np.random.random_sample(nSamples)-0.5)*np.pi
-        mjd = 59580.0
+        mjd = ModifiedJulianDate(TAI=59580.0)
         control_distance = _distanceToSun(ra, dec, mjd)
         self.assertIsInstance(control_distance, np.ndarray)
         for ix, (rr, dd) in enumerate(zip(ra, dec)):
@@ -220,7 +222,8 @@ class astrometryUnitTest(unittest.TestCase):
         Test that distanceToSun is consistent with _distanceToSun
         """
 
-        for mjd, ra, dec in zip((57632.1, 45623.4, 55682.3), (112.0, 24.0, 231.2), (-25.0, 23.4, -60.0)):
+        for tai, ra, dec in zip((57632.1, 45623.4, 55682.3), (112.0, 24.0, 231.2), (-25.0, 23.4, -60.0)):
+             mjd = ModifiedJulianDate(TAI=tai)
              dd_deg = distanceToSun(ra, dec, mjd)
              dd_rad = _distanceToSun(np.radians(ra), np.radians(dec), mjd)
              self.assertAlmostEqual(np.radians(dd_deg), dd_rad, 10)
@@ -231,7 +234,8 @@ class astrometryUnitTest(unittest.TestCase):
         Test that solarRaDec is consistent with _solarRaDec
         """
 
-        for mjd in (57664.2, 53478.9, 45672.1):
+        for tai in (57664.2, 53478.9, 45672.1):
+            mjd = ModifiedJulianDate(TAI=tai)
             ra_deg, dec_deg = solarRaDec(mjd)
             ra_rad, dec_rad = _solarRaDec(mjd)
             self.assertAlmostEqual(np.radians(ra_deg), ra_rad, 10)
@@ -261,8 +265,8 @@ class astrometryUnitTest(unittest.TestCase):
         sun_dec_list = [np.radians(-22.0-47.0/60.0-40.27/3600.0),
                         np.radians(22.0+30.0/60.0+0.73/3600.0)]
 
-        for mjd, raS, decS in zip(mjd_list, sun_ra_list, sun_dec_list):
-
+        for tai, raS, decS in zip(mjd_list, sun_ra_list, sun_dec_list):
+            mjd=ModifiedJulianDate(TAI=tai)
             ra_list = np.random.random_sample(nStars)*2.0*np.pi
             dec_list =(np.random.random_sample(nStars)-0.5)*np.pi
             distance_list = _distanceToSun(ra_list, dec_list, mjd)
@@ -868,7 +872,7 @@ class astrometryUnitTest(unittest.TestCase):
             self.assertFalse(np.isnan(ra_icrs).any())
             self.assertFalse(np.isnan(dec_icrs).any())
 
-            valid_pts = np.where(_distanceToSun(ra_in, dec_in, mjd.TDB)>0.25*np.pi)[0]
+            valid_pts = np.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*np.pi)[0]
 
             self.assertGreater(len(valid_pts), 0)
 
@@ -902,17 +906,17 @@ class astrometryUnitTest(unittest.TestCase):
 
         site = Site(name='LSST')
 
-        for mjd in (53000.0, 53241.6, 58504.6):
+        for tai in (53000.0, 53241.6, 58504.6):
             for includeRefraction in (True, False):
                 for raPointing in (23.5, 256.9, 100.0):
                     for decPointing in (-12.0, 45.0, 66.8):
 
-                        obs = ObservationMetaData(mjd=mjd, site=site)
+                        obs = ObservationMetaData(mjd=tai, site=site)
 
                         raZenith, decZenith = _raDecFromAltAz(0.5*np.pi, 0.0, obs)
 
                         obs = ObservationMetaData(pointingRA=raPointing, pointingDec=decPointing,
-                                                  mjd=mjd, site=site)
+                                                  mjd=tai, site=site)
 
                         rr = np.random.random_sample(nSamples)*np.radians(50.0)
                         theta = np.random.random_sample(nSamples)*2.0*np.pi
@@ -929,7 +933,7 @@ class astrometryUnitTest(unittest.TestCase):
                                                               includeRefraction=includeRefraction,
                                                               epoch=2000.0)
 
-                        valid_pts = np.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*np.pi)[0]
+                        valid_pts = np.where(_distanceToSun(ra_in, dec_in, obs.mjd)>0.25*np.pi)[0]
 
                         self.assertGreater(len(valid_pts), 0)
 

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -898,6 +898,15 @@ class astrometryUnitTest(unittest.TestCase):
 
         self.assertAlmostEqual(output,7.851689251070859132e-01,6)
 
+        # test that passing in a numpy array and passing in floats
+        # give the same results
+        np.random.seed(712)
+        zd_arr = np.random.random_sample(20)*np.pi*0.2
+        control_refraction = applyRefraction(zd_arr, coeffs[0], coeffs[1])
+        for ix, zz in enumerate(zd_arr):
+            test_refraction = applyRefraction(zz, coeffs[0], coeffs[1])
+            self.assertAlmostEqual(test_refraction, control_refraction[ix], 12)
+
 
 
 def suite():

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -759,50 +759,47 @@ class astrometryUnitTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, 5.0, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("dec", context.exception.args[0])
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same "
-                         "type, either floats or numpy arrays")
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(5.0, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same type, "
-                         "either floats or numpy arrays")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("dec", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=5.0, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same type, "
-                         "either floats or numpy arrays")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("pm_ra", context.exception.args[0])
+
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=5.0,
                                       parallax=parallax, v_rad=v_rad, mjd=mjd)
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same type, "
-                         "either floats or numpy arrays")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("pm_dec", context.exception.args[0])
+
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=5.0, v_rad=v_rad, mjd=mjd)
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same type, "
-                         "either floats or numpy arrays")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("parallax", context.exception.args[0])
+
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs, pm_ra=pm_ra, pm_dec=pm_dec,
                                       parallax=parallax, v_rad=5.0, mjd=mjd)
 
-        self.assertEqual(context.exception.args[0],
-                         "The inputs to appGeoFromICRS should all be the same type, "
-                         "either floats or numpy arrays")
+        self.assertIn("The input arguments:", context.exception.args[0])
+        self.assertIn("v_rad", context.exception.args[0])
 
         with self.assertRaises(RuntimeError) as context:
             ra, dec = _appGeoFromICRS(ra_icrs, dec_icrs[:2], pm_ra=pm_ra, pm_dec=pm_dec,

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -964,7 +964,14 @@ class astrometryUnitTest(unittest.TestCase):
                             self.assertIsInstance(ra_f, np.float)
                             self.assertIsInstance(dec_f, np.float)
                             dist_f = arcsecFromRadians(pal.dsep(ra_obs[ix], dec_obs[ix], ra_f, dec_f))
-                            self.assertLess(dist_f, 0.0001)
+                            self.assertLess(dist_f, 1.0e-9)
+
+                            ra_f, dec_f = _appGeoFromObserved(ra_obs[ix], dec_obs[ix], obs_metadata=obs,
+                                                              includeRefraction=includeRefraction)
+                            self.assertIsInstance(ra_f, np.float)
+                            self.assertIsInstance(dec_f, np.float)
+                            dist_f = arcsecFromRadians(pal.dsep(ra_app[ix], dec_app[ix], ra_f, dec_f))
+                            self.assertLess(dist_f, 1.0e-9)
 
 
     def test_icrsFromObservedExceptions(self):
@@ -1081,7 +1088,7 @@ class astrometryUnitTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             ra_out, dec_out = _appGeoFromObserved(ra_in[:2], dec_in, obs_metadata=obs)
         self.assertEqual(context.exception.args[0],
-                         "You passed 2 RAs but 10 Decs to appGeoFromObserved")
+                         "The arrays input to appGeoFromObserved all need to have the same length")
 
 
     def testRefractionCoefficients(self):

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -15,7 +15,7 @@ still agree to within one part in 10^5)
 
 from __future__ import with_statement
 
-import numpy
+import numpy as np
 
 import os
 import unittest
@@ -42,10 +42,10 @@ from lsst.sims.utils import refractionCoefficients, applyRefraction
 def makeObservationMetaData():
     #create a cartoon ObservationMetaData object
     mjd = 52000.0
-    alt = numpy.pi/2.0
+    alt = np.pi/2.0
     az = 0.0
     band = 'r'
-    testSite = Site(latitude=numpy.degrees(0.5), longitude=numpy.degrees(1.1), height=3000,
+    testSite = Site(latitude=np.degrees(0.5), longitude=np.degrees(1.1), height=3000,
                     temperature=260.0, pressure=725.0, lapseRate=0.005, humidity=0.4)
     obsTemp = ObservationMetaData(site=testSite, mjd=mjd)
     centerRA, centerDec = _raDecFromAltAz(alt, az, obsTemp)
@@ -57,7 +57,7 @@ def makeObservationMetaData():
     obsDict['Opsim_expmjd'] = mjd
     radius = 0.1
     phoSimMetaData = OrderedDict([
-                      (k, (obsDict[k],numpy.dtype(type(obsDict[k])))) for k in obsDict])
+                      (k, (obsDict[k],np.dtype(type(obsDict[k])))) for k in obsDict])
 
     obs_metadata = ObservationMetaData(boundType='circle', boundLength=2.0*radius,
                                        phoSimMetaData=phoSimMetaData, site=testSite)
@@ -70,21 +70,21 @@ def makeRandomSample(raCenter=None, decCenter=None, radius=None):
     #create a random sample of object data
 
     nsamples=100
-    numpy.random.seed(32)
+    np.random.seed(32)
 
     if raCenter is None or decCenter is None or radius is None:
-        ra = numpy.random.sample(nsamples)*2.0*numpy.pi
-        dec = (numpy.random.sample(nsamples)-0.5)*numpy.pi
+        ra = np.random.sample(nsamples)*2.0*np.pi
+        dec = (np.random.sample(nsamples)-0.5)*np.pi
     else:
-        rr = numpy.random.sample(nsamples)*radius
-        theta = numpy.random.sample(nsamples)*2.0*numpy.pi
-        ra = raCenter + rr*numpy.cos(theta)
-        dec = decCenter + rr*numpy.cos(theta)
+        rr = np.random.sample(nsamples)*radius
+        theta = np.random.sample(nsamples)*2.0*np.pi
+        ra = raCenter + rr*np.cos(theta)
+        dec = decCenter + rr*np.cos(theta)
 
-    pm_ra = (numpy.random.sample(nsamples)-0.5)*0.1
-    pm_dec = (numpy.random.sample(nsamples)-0.5)*0.1
-    parallax = numpy.random.sample(nsamples)*0.01
-    v_rad = numpy.random.sample(nsamples)*1000.0
+    pm_ra = (np.random.sample(nsamples)-0.5)*0.1
+    pm_dec = (np.random.sample(nsamples)-0.5)*0.1
+    parallax = np.random.sample(nsamples)*0.01
+    v_rad = np.random.sample(nsamples)*1000.0
 
     return ra, dec, pm_ra, pm_dec, parallax, v_rad
 
@@ -106,13 +106,13 @@ class astrometryUnitTest(unittest.TestCase):
         #these would be set to meaningful values.  Because we are generating
         #an artificial set of inputs that must comport to the baseline SLALIB
         #inputs, these are set arbitrarily by hand
-        self.metadata['pointingRA'] = (numpy.radians(200.0), float)
-        self.metadata['pointingDec'] = (numpy.radians(-30.0), float)
+        self.metadata['pointingRA'] = (np.radians(200.0), float)
+        self.metadata['pointingDec'] = (np.radians(-30.0), float)
         self.metadata['Opsim_rotskypos'] = (1.0, float)
 
         # these were the LSST site parameters as coded when this unit test was written
-        self.test_site=Site(longitude=numpy.degrees(-1.2320792),
-                            latitude=numpy.degrees(-0.517781017),
+        self.test_site=Site(longitude=np.degrees(-1.2320792),
+                            latitude=np.degrees(-0.517781017),
                             height=2650.0,
                             temperature=11.505,
                             pressure=749.3,
@@ -141,7 +141,7 @@ class astrometryUnitTest(unittest.TestCase):
         http://aa.usno.navy.mil/data/docs/geocentric.php
         """
 
-        hour = numpy.radians(360.0/24.0)
+        hour = np.radians(360.0/24.0)
         minute = hour/60.0
         second = minute/60.0
 
@@ -150,8 +150,8 @@ class astrometryUnitTest(unittest.TestCase):
         sun_ra_list = [18.0*hour + 56.0*minute + 51.022*second,
                        4.0*hour + 51.0*minute + 22.776*second,]
 
-        sun_dec_list = [numpy.radians(-22.0-47.0/60.0-40.27/3600.0),
-                        numpy.radians(22.0+30.0/60.0+0.73/3600.0)]
+        sun_dec_list = [np.radians(-22.0-47.0/60.0-40.27/3600.0),
+                        np.radians(22.0+30.0/60.0+0.73/3600.0)]
 
         for raS, decS, mjd in zip(sun_ra_list, sun_dec_list, mjd_list):
 
@@ -159,47 +159,47 @@ class astrometryUnitTest(unittest.TestCase):
             self.assertLess(arcsecFromRadians(_distanceToSun(raS, decS, mjd)), 5.0)
 
             # find Sun's Cartesian coordinates
-            sun_x = numpy.cos(decS)*numpy.cos(raS)
-            sun_y = numpy.cos(decS)*numpy.sin(raS)
-            sun_z = numpy.sin(decS)
+            sun_x = np.cos(decS)*np.cos(raS)
+            sun_y = np.cos(decS)*np.sin(raS)
+            sun_z = np.sin(decS)
 
             # now choose positions that are a set distance away from the Sun, and make sure
             # that _distanceToSun returns the expected result
-            for theta in (numpy.pi/2.0, numpy.pi/4.0, -numpy.pi/3.0):
+            for theta in (np.pi/2.0, np.pi/4.0, -np.pi/3.0):
 
                 # displace by rotating about z axis
-                new_x = sun_x*numpy.cos(theta)+sun_y*numpy.sin(theta)
-                new_y = -sun_x*numpy.sin(theta)+sun_y*numpy.cos(theta)
+                new_x = sun_x*np.cos(theta)+sun_y*np.sin(theta)
+                new_y = -sun_x*np.sin(theta)+sun_y*np.cos(theta)
                 new_z = sun_z
 
-                new_ra = numpy.arctan2(new_y, new_x)
-                new_dec = numpy.arctan2(new_z, numpy.sqrt(new_x*new_x+new_y*new_y))
+                new_ra = np.arctan2(new_y, new_x)
+                new_dec = np.arctan2(new_z, np.sqrt(new_x*new_x+new_y*new_y))
 
                 dd = _distanceToSun(new_ra, new_dec, mjd)
                 hh = haversine(raS, decS, new_ra, new_dec)
-                self.assertLess(numpy.abs(arcsecFromRadians(dd-hh)), 5.0)
+                self.assertLess(np.abs(arcsecFromRadians(dd-hh)), 5.0)
 
                 # displace by rotating about y axis
-                new_x = sun_x*numpy.cos(theta)+sun_z*numpy.sin(theta)
+                new_x = sun_x*np.cos(theta)+sun_z*np.sin(theta)
                 new_y = sun_y
-                new_z = -sun_x*numpy.sin(theta)+sun_z*numpy.cos(theta)
+                new_z = -sun_x*np.sin(theta)+sun_z*np.cos(theta)
 
-                new_ra = numpy.arctan2(new_y, new_x)
-                new_dec = numpy.arctan2(new_z, numpy.sqrt(new_x*new_x+new_y*new_y))
+                new_ra = np.arctan2(new_y, new_x)
+                new_dec = np.arctan2(new_z, np.sqrt(new_x*new_x+new_y*new_y))
                 dd = _distanceToSun(new_ra, new_dec, mjd)
                 hh = haversine(raS, decS, new_ra, new_dec)
-                self.assertLess(numpy.abs(arcsecFromRadians(dd-hh)), 5.0)
+                self.assertLess(np.abs(arcsecFromRadians(dd-hh)), 5.0)
 
                 # displace by rotating about x axis
                 new_x = sun_x
-                new_y = sun_y*numpy.cos(theta)+sun_z*numpy.sin(theta)
-                new_z = -sun_y*numpy.sin(theta)+sun_z*numpy.cos(theta)
+                new_y = sun_y*np.cos(theta)+sun_z*np.sin(theta)
+                new_z = -sun_y*np.sin(theta)+sun_z*np.cos(theta)
 
-                new_ra = numpy.arctan2(new_y, new_x)
-                new_dec = numpy.arctan2(new_z, numpy.sqrt(new_x*new_x+new_y*new_y))
+                new_ra = np.arctan2(new_y, new_x)
+                new_dec = np.arctan2(new_z, np.sqrt(new_x*new_x+new_y*new_y))
                 dd = _distanceToSun(new_ra, new_dec, mjd)
                 hh = haversine(raS, decS, new_ra, new_dec)
-                self.assertLess(numpy.abs(arcsecFromRadians(dd-hh)), 5.0)
+                self.assertLess(np.abs(arcsecFromRadians(dd-hh)), 5.0)
 
 
     def testDistanceToSunDeg(self):
@@ -209,8 +209,8 @@ class astrometryUnitTest(unittest.TestCase):
 
         for mjd, ra, dec in zip((57632.1, 45623.4, 55682.3), (112.0, 24.0, 231.2), (-25.0, 23.4, -60.0)):
              dd_deg = distanceToSun(ra, dec, mjd)
-             dd_rad = _distanceToSun(numpy.radians(ra), numpy.radians(dec), mjd)
-             self.assertAlmostEqual(numpy.radians(dd_deg), dd_rad, 10)
+             dd_rad = _distanceToSun(np.radians(ra), np.radians(dec), mjd)
+             self.assertAlmostEqual(np.radians(dd_deg), dd_rad, 10)
 
 
     def testSolarRaDecDeg(self):
@@ -221,8 +221,8 @@ class astrometryUnitTest(unittest.TestCase):
         for mjd in (57664.2, 53478.9, 45672.1):
             ra_deg, dec_deg = solarRaDec(mjd)
             ra_rad, dec_rad = _solarRaDec(mjd)
-            self.assertAlmostEqual(numpy.radians(ra_deg), ra_rad, 10)
-            self.assertAlmostEqual(numpy.radians(dec_deg), dec_rad, 10)
+            self.assertAlmostEqual(np.radians(ra_deg), ra_rad, 10)
+            self.assertAlmostEqual(np.radians(dec_deg), dec_rad, 10)
 
 
     def testDistanceToSunArray(self):
@@ -233,10 +233,10 @@ class astrometryUnitTest(unittest.TestCase):
         http://aa.usno.navy.mil/data/docs/geocentric.php
         """
 
-        numpy.random.seed(77)
+        np.random.seed(77)
         nStars = 100
 
-        hour = numpy.radians(360.0/24.0)
+        hour = np.radians(360.0/24.0)
         minute = hour/60.0
         second = minute/60.0
 
@@ -245,16 +245,16 @@ class astrometryUnitTest(unittest.TestCase):
         sun_ra_list = [18.0*hour + 56.0*minute + 51.022*second,
                        4.0*hour + 51.0*minute + 22.776*second,]
 
-        sun_dec_list = [numpy.radians(-22.0-47.0/60.0-40.27/3600.0),
-                        numpy.radians(22.0+30.0/60.0+0.73/3600.0)]
+        sun_dec_list = [np.radians(-22.0-47.0/60.0-40.27/3600.0),
+                        np.radians(22.0+30.0/60.0+0.73/3600.0)]
 
         for mjd, raS, decS in zip(mjd_list, sun_ra_list, sun_dec_list):
 
-            ra_list = numpy.random.random_sample(nStars)*2.0*numpy.pi
-            dec_list =(numpy.random.random_sample(nStars)-0.5)*numpy.pi
+            ra_list = np.random.random_sample(nStars)*2.0*np.pi
+            dec_list =(np.random.random_sample(nStars)-0.5)*np.pi
             distance_list = _distanceToSun(ra_list, dec_list, mjd)
-            distance_control = haversine(ra_list, dec_list, numpy.array([raS]*nStars), numpy.array([decS]*nStars))
-            numpy.testing.assert_array_almost_equal(distance_list, distance_control, 5)
+            distance_control = haversine(ra_list, dec_list, np.array([raS]*nStars), np.array([decS]*nStars))
+            np.testing.assert_array_almost_equal(distance_list, distance_control, 5)
 
 
     def testAstrometryExceptions(self):
@@ -265,8 +265,8 @@ class astrometryUnitTest(unittest.TestCase):
         obs_metadata = makeObservationMetaData()
         ra, dec, pm_ra, pm_dec, parallax, v_rad = makeRandomSample()
 
-        raShort = numpy.array([1.0])
-        decShort = numpy.array([1.0])
+        raShort = np.array([1.0])
+        decShort = np.array([1.0])
 
 
         ##########test refractionCoefficients
@@ -281,7 +281,7 @@ class astrometryUnitTest(unittest.TestCase):
         zd = [0.1, 0.2]
         self.assertRaises(RuntimeError, applyRefraction, zd, x, y)
 
-        zd = numpy.array([0.1, 0.2])
+        zd = np.array([0.1, 0.2])
         rzd = applyRefraction(zd, x, y)
 
         ##########test _applyPrecession
@@ -305,10 +305,10 @@ class astrometryUnitTest(unittest.TestCase):
         parallaxList = list(parallax)
         v_radList = list(v_rad)
 
-        pm_raShort = numpy.array([pm_ra[0]])
-        pm_decShort = numpy.array([pm_dec[0]])
-        parallaxShort = numpy.array([parallax[0]])
-        v_radShort = numpy.array([v_rad[0]])
+        pm_raShort = np.array([pm_ra[0]])
+        pm_decShort = np.array([pm_dec[0]])
+        parallaxShort = np.array([parallax[0]])
+        v_radShort = np.array([v_rad[0]])
 
         #test without mjd
         self.assertRaises(RuntimeError, _applyProperMotion,
@@ -432,8 +432,8 @@ class astrometryUnitTest(unittest.TestCase):
 
     def test_applyPrecession(self):
 
-        ra=numpy.zeros((3),dtype=float)
-        dec=numpy.zeros((3),dtype=float)
+        ra=np.zeros((3),dtype=float)
+        dec=np.zeros((3),dtype=float)
 
         ra[0]=2.549091039839124218e+00
         dec[0]=5.198752733024248895e-01
@@ -457,59 +457,59 @@ class astrometryUnitTest(unittest.TestCase):
         VF=0.21094502
         pal_das2r=4.8481368110953599358991410235794797595635330237270e-6;
 
-        numpy.random.seed(18)
+        np.random.seed(18)
         nSamples = 1000
 
-        mjdList = numpy.random.random_sample(20)*20000.0 + 45000.0
+        mjdList = np.random.random_sample(20)*20000.0 + 45000.0
 
         for mjd in mjdList:
 
-            raList_icrs = numpy.random.random_sample(nSamples)*2.0*numpy.pi
-            decList_icrs = (numpy.random.random_sample(nSamples)-0.5)*numpy.pi
+            raList_icrs = np.random.random_sample(nSamples)*2.0*np.pi
+            decList_icrs = (np.random.random_sample(nSamples)-0.5)*np.pi
 
             # stars' original position in Cartesian space
-            x_list_icrs = numpy.cos(decList_icrs)*numpy.cos(raList_icrs)
-            y_list_icrs = numpy.cos(decList_icrs)*numpy.sin(raList_icrs)
-            z_list_icrs = numpy.sin(decList_icrs)
+            x_list_icrs = np.cos(decList_icrs)*np.cos(raList_icrs)
+            y_list_icrs = np.cos(decList_icrs)*np.sin(raList_icrs)
+            z_list_icrs = np.sin(decList_icrs)
 
 
-            pm_ra = (numpy.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
-            pm_dec = (numpy.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
-            px = numpy.random.random_sample(nSamples)*radiansFromArcsec(1.0)
-            v_rad = numpy.random.random_sample(nSamples)*200.0
+            pm_ra = (np.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
+            pm_dec = (np.random.random_sample(nSamples)-0.5)*radiansFromArcsec(1.0)
+            px = np.random.random_sample(nSamples)*radiansFromArcsec(1.0)
+            v_rad = np.random.random_sample(nSamples)*200.0
 
 
             ra_list_pm, dec_list_pm = _applyProperMotion(raList_icrs, decList_icrs,
-                                                         pm_ra*numpy.cos(decList_icrs),
+                                                         pm_ra*np.cos(decList_icrs),
                                                          pm_dec, px, v_rad, mjd=ModifiedJulianDate(TAI=mjd))
 
             # stars' Cartesian position after proper motion is applied
-            x_list_pm = numpy.cos(dec_list_pm)*numpy.cos(ra_list_pm)
-            y_list_pm = numpy.cos(dec_list_pm)*numpy.sin(ra_list_pm)
-            z_list_pm = numpy.sin(dec_list_pm)
+            x_list_pm = np.cos(dec_list_pm)*np.cos(ra_list_pm)
+            y_list_pm = np.cos(dec_list_pm)*np.sin(ra_list_pm)
+            z_list_pm = np.sin(dec_list_pm)
 
             ###############################################################
             # The code below is copied from palMapqk.c in palpy/cextern/pal
             params = pal.mappa(2000.0, mjd)
             pmt = params[0]
-            eb = numpy.array([params[1], params[2], params[3]])
+            eb = np.array([params[1], params[2], params[3]])
 
             pxr = px*pal_das2r
 
             w = VF*v_rad*pxr
 
-            motion_per_year = numpy.array([-1.0*pm_ra*y_list_icrs - pm_dec*numpy.cos(raList_icrs)*numpy.sin(decList_icrs) + w*x_list_icrs,
-                                     pm_ra*x_list_icrs - pm_dec*numpy.sin(raList_icrs)*numpy.sin(decList_icrs) + w*y_list_icrs,
-                                     pm_dec*numpy.cos(decList_icrs) + w*z_list_icrs])
+            motion_per_year = np.array([-1.0*pm_ra*y_list_icrs - pm_dec*np.cos(raList_icrs)*np.sin(decList_icrs) + w*x_list_icrs,
+                                     pm_ra*x_list_icrs - pm_dec*np.sin(raList_icrs)*np.sin(decList_icrs) + w*y_list_icrs,
+                                     pm_dec*np.cos(decList_icrs) + w*z_list_icrs])
 
 
-            xyz_control = numpy.array([
+            xyz_control = np.array([
                                       x_list_icrs + pmt*motion_per_year[0] - pxr*eb[0],
                                       y_list_icrs + pmt*motion_per_year[1] - pxr*eb[1],
                                       z_list_icrs + pmt*motion_per_year[2] - pxr*eb[2]
                                       ])
 
-            xyz_norm = numpy.sqrt(numpy.power(xyz_control[0],2) + numpy.power(xyz_control[1],2) + numpy.power(xyz_control[2],2))
+            xyz_norm = np.sqrt(np.power(xyz_control[0],2) + np.power(xyz_control[1],2) + np.power(xyz_control[2],2))
 
             # stars' Cartesian position after applying the control proper motion method
             xyz_control[0] = xyz_control[0]/xyz_norm
@@ -518,15 +518,15 @@ class astrometryUnitTest(unittest.TestCase):
 
             # this is the Cartesian distance between the stars' positions as found by _applyProperMotion
             # and the distance as found by the control proper motion code above
-            distance = numpy.sqrt(numpy.power(x_list_pm-xyz_control[0],2) + numpy.power(y_list_pm-xyz_control[1],2) +
-                                  numpy.power(z_list_pm-xyz_control[2],2))
+            distance = np.sqrt(np.power(x_list_pm-xyz_control[0],2) + np.power(y_list_pm-xyz_control[1],2) +
+                                  np.power(z_list_pm-xyz_control[2],2))
 
             # this is the Cartesian distance between the stars' original positions on the celestial sphere
             # and their positions after the control proper motion was applied
-            correction = numpy.sqrt(numpy.power(xyz_control[0]-x_list_icrs,2) + numpy.power(xyz_control[1]-y_list_icrs,2) +
-                                    numpy.power(xyz_control[2]-z_list_icrs,2))
+            correction = np.sqrt(np.power(xyz_control[0]-x_list_icrs,2) + np.power(xyz_control[1]-y_list_icrs,2) +
+                                    np.power(xyz_control[2]-z_list_icrs,2))
 
-            dex = numpy.argmax(distance)
+            dex = np.argmax(distance)
             msg = 'pm %e %e vr %e px %e; time %e; err %e arcsec; corr %e' % \
             (arcsecFromRadians(pm_ra[dex]), arcsecFromRadians(pm_dec[dex]),
              v_rad[dex], arcsecFromRadians(px[dex]), pmt, arcsecFromRadians(distance[dex]),
@@ -550,7 +550,7 @@ class astrometryUnitTest(unittest.TestCase):
 
         """
 
-        hours = numpy.radians(360.0/24.0)
+        hours = np.radians(360.0/24.0)
         minutes = hours/60.0
         seconds = minutes/60.0
 
@@ -558,7 +558,7 @@ class astrometryUnitTest(unittest.TestCase):
         # data taken from
         # http://aa.usno.navy.mil/data/docs/geocentric.php
         ra_icrs = 14.0*hours + 15.0*minutes + 39.67207*seconds
-        dec_icrs = numpy.radians(19.0 + 10.0/60.0 + 56.673/3600.0)
+        dec_icrs = np.radians(19.0 + 10.0/60.0 + 56.673/3600.0)
         pm_ra = radiansFromArcsec(-1.0939)
         pm_dec = radiansFromArcsec(-2.00006)
         v_rad = -5.19
@@ -574,29 +574,29 @@ class astrometryUnitTest(unittest.TestCase):
 
         mjd_list.append(mjd)
         ra_app_list.append(14.0*hours + 16.0*minutes + 19.59*seconds)
-        dec_app_list.append(numpy.radians(19.0 + 6.0/60.0 + 19.56/3600.0))
+        dec_app_list.append(np.radians(19.0 + 6.0/60.0 + 19.56/3600.0))
 
         jd = 2457187.208333
         mjd = jd-2400000.5
         mjd_list.append(mjd)
         ra_app_list.append(14.0*hours + 16.0*minutes + 22.807*seconds)
-        dec_app_list.append(numpy.radians(19.0+6.0/60.0+18.12/3600.0))
+        dec_app_list.append(np.radians(19.0+6.0/60.0+18.12/3600.0))
 
         jd = 2457472.625000
         mjd = jd-2400000.5
         mjd_list.append(mjd)
         ra_app_list.append(14.0*hours + 16.0*minutes + 24.946*seconds)
-        dec_app_list.append(numpy.radians(19.0 + 5.0/60.0 + 49.65/3600.0))
+        dec_app_list.append(np.radians(19.0 + 5.0/60.0 + 49.65/3600.0))
 
         for mjd, ra_app, dec_app in zip(mjd_list, ra_app_list, dec_app_list):
             obs = ObservationMetaData(mjd=mjd)
 
-            ra_test, dec_test = _appGeoFromICRS(numpy.array([ra_icrs]), numpy.array([dec_icrs]),
+            ra_test, dec_test = _appGeoFromICRS(np.array([ra_icrs]), np.array([dec_icrs]),
                                                 mjd=obs.mjd,
-                                                pm_ra=numpy.array([pm_ra]),
-                                                pm_dec=numpy.array([pm_dec]),
-                                                v_rad=numpy.array([v_rad]),
-                                                parallax=numpy.array([px]),
+                                                pm_ra=np.array([pm_ra]),
+                                                pm_dec=np.array([pm_dec]),
+                                                v_rad=np.array([v_rad]),
+                                                parallax=np.array([px]),
                                                 epoch=2000.0)
 
             distance = arcsecFromRadians(haversine(ra_app, dec_app, ra_test[0], dec_test[0]))
@@ -607,7 +607,7 @@ class astrometryUnitTest(unittest.TestCase):
         # data taken from
         # http://simbad.u-strasbg.fr/simbad/sim-id?Ident=Sirius
         ra_icrs = 6.0*hours + 45.0*minutes + 8.91728*seconds
-        dec_icrs = numpy.radians(-16.0 - 42.0/60.0 -58.0171/3600.0)
+        dec_icrs = np.radians(-16.0 - 42.0/60.0 -58.0171/3600.0)
         pm_ra = radiansFromArcsec(-0.54601)
         pm_dec = radiansFromArcsec(-1.22307)
         px = radiansFromArcsec(0.37921)
@@ -620,27 +620,27 @@ class astrometryUnitTest(unittest.TestCase):
         jd = 2457247.000000
         mjd_list.append(jd-2400000.5)
         ra_app_list.append(6.0*hours + 45.0*minutes + 49.276*seconds)
-        dec_app_list.append(numpy.radians(-16.0 - 44.0/60.0 - 18.69/3600.0))
+        dec_app_list.append(np.radians(-16.0 - 44.0/60.0 - 18.69/3600.0))
 
         jd = 2456983.958333
         mjd_list.append(jd-2400000.5)
         ra_app_list.append(6.0*hours + 45.0*minutes + 49.635*seconds)
-        dec_app_list.append(numpy.radians(-16.0 - 44.0/60.0 - 17.04/3600.0))
+        dec_app_list.append(np.radians(-16.0 - 44.0/60.0 - 17.04/3600.0))
 
         jd = 2457523.958333
         mjd_list.append(jd-2400000.5)
         ra_app_list.append(6.0*hours + 45.0*minutes + 50.99*seconds)
-        dec_app_list.append(numpy.radians(-16.0 - 44.0/60.0 - 39.76/3600.0))
+        dec_app_list.append(np.radians(-16.0 - 44.0/60.0 - 39.76/3600.0))
 
         for mjd, ra_app, dec_app in zip(mjd_list, ra_app_list, dec_app_list):
             obs = ObservationMetaData(mjd=mjd)
 
-            ra_test, dec_test = _appGeoFromICRS(numpy.array([ra_icrs]), numpy.array([dec_icrs]),
+            ra_test, dec_test = _appGeoFromICRS(np.array([ra_icrs]), np.array([dec_icrs]),
                                                 mjd=obs.mjd,
-                                                pm_ra=numpy.array([pm_ra]),
-                                                pm_dec=numpy.array([pm_dec]),
-                                                v_rad=numpy.array([v_rad]),
-                                                parallax=numpy.array([px]),
+                                                pm_ra=np.array([pm_ra]),
+                                                pm_dec=np.array([pm_dec]),
+                                                v_rad=np.array([v_rad]),
+                                                parallax=np.array([px]),
                                                 epoch=2000.0)
 
             distance = arcsecFromRadians(haversine(ra_app, dec_app, ra_test[0], dec_test[0]))
@@ -662,15 +662,15 @@ class astrometryUnitTest(unittest.TestCase):
         from the sun.
         """
 
-        numpy.random.seed(412)
+        np.random.seed(412)
         nSamples = 100
 
         mjd2000 = pal.epb(2000.0) # convert epoch to mjd
 
         for mjd in (53000.0, 53241.6, 58504.6):
 
-            ra_in = numpy.random.random_sample(nSamples)*2.0*numpy.pi
-            dec_in = (numpy.random.random_sample(nSamples)-0.5)*numpy.pi
+            ra_in = np.random.random_sample(nSamples)*2.0*np.pi
+            dec_in = (np.random.random_sample(nSamples)-0.5)*np.pi
 
 
             ra_app, dec_app = _appGeoFromICRS(ra_in, dec_in, mjd=ModifiedJulianDate(TAI=mjd))
@@ -678,10 +678,10 @@ class astrometryUnitTest(unittest.TestCase):
             ra_icrs, dec_icrs = _icrsFromAppGeo(ra_app, dec_app,
                                                 epoch=2000.0, mjd=ModifiedJulianDate(TAI=mjd))
 
-            self.assertFalse(numpy.isnan(ra_icrs).any())
-            self.assertFalse(numpy.isnan(dec_icrs).any())
+            self.assertFalse(np.isnan(ra_icrs).any())
+            self.assertFalse(np.isnan(dec_icrs).any())
 
-            valid_pts = numpy.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*numpy.pi)[0]
+            valid_pts = np.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*np.pi)[0]
 
             self.assertGreater(len(valid_pts), 0)
 
@@ -699,7 +699,7 @@ class astrometryUnitTest(unittest.TestCase):
         45 degrees from the sun and at zenith distances less than 70 degrees.
         """
 
-        numpy.random.seed(412)
+        np.random.seed(412)
         nSamples = 100
 
         mjd2000 = pal.epb(2000.0) # convert epoch to mjd
@@ -713,16 +713,16 @@ class astrometryUnitTest(unittest.TestCase):
 
                         obs = ObservationMetaData(mjd=mjd, site=site)
 
-                        raZenith, decZenith = _raDecFromAltAz(0.5*numpy.pi, 0.0, obs)
+                        raZenith, decZenith = _raDecFromAltAz(0.5*np.pi, 0.0, obs)
 
                         obs = ObservationMetaData(pointingRA=raPointing, pointingDec=decPointing,
                                                   mjd=mjd, site=site)
 
-                        rr = numpy.random.random_sample(nSamples)*numpy.radians(50.0)
-                        theta = numpy.random.random_sample(nSamples)*2.0*numpy.pi
+                        rr = np.random.random_sample(nSamples)*np.radians(50.0)
+                        theta = np.random.random_sample(nSamples)*2.0*np.pi
 
-                        ra_in = raZenith + rr*numpy.cos(theta)
-                        dec_in = decZenith + rr*numpy.sin(theta)
+                        ra_in = raZenith + rr*np.cos(theta)
+                        dec_in = decZenith + rr*np.sin(theta)
 
                         # test a round-trip between observedFromICRS and icrsFromObserved
                         ra_obs, dec_obs = _observedFromICRS(ra_in, dec_in, obs_metadata=obs,
@@ -733,7 +733,7 @@ class astrometryUnitTest(unittest.TestCase):
                                                               includeRefraction=includeRefraction,
                                                               epoch=2000.0)
 
-                        valid_pts = numpy.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*numpy.pi)[0]
+                        valid_pts = np.where(_distanceToSun(ra_in, dec_in, mjd)>0.25*np.pi)[0]
 
                         self.assertGreater(len(valid_pts), 0)
 
@@ -759,9 +759,9 @@ class astrometryUnitTest(unittest.TestCase):
         """
         Test that _icrsFromObserved raises exceptions when it is supposed to.
         """
-        numpy.random.seed(33)
-        ra_in = numpy.random.random_sample(10)
-        dec_in = numpy.random.random_sample(10)
+        np.random.seed(33)
+        ra_in = np.random.random_sample(10)
+        dec_in = np.random.random_sample(10)
         with self.assertRaises(RuntimeError) as context:
             ra_out, dec_out = _icrsFromObserved(ra_in, dec_in, epoch=2000.0)
         self.assertEqual(context.exception.args[0],
@@ -791,7 +791,7 @@ class astrometryUnitTest(unittest.TestCase):
         Test that _appGeoFromObserved really does invert _observedFromAppGeo
         """
         mjd = 58350.0
-        site = Site(longitude=numpy.degrees(0.235), latitude=numpy.degrees(-1.2), name='LSST')
+        site = Site(longitude=np.degrees(0.235), latitude=np.degrees(-1.2), name='LSST')
         raCenter, decCenter = raDecFromAltAz(90.0, 0.0,
                                              ObservationMetaData(mjd=mjd, site=site))
 
@@ -799,21 +799,21 @@ class astrometryUnitTest(unittest.TestCase):
                                   mjd=ModifiedJulianDate(TAI=58350.0),
                                   site=site)
 
-        numpy.random.seed(125543)
+        np.random.seed(125543)
         nSamples = 200
 
         # Note: the PALPY routines in question start to become inaccurate at
         # a zenith distance of about 75 degrees, so we restrict our test points
         # to be within 50 degrees of the telescope pointing, which is at zenith
         # in a flat sky approximation
-        rr = numpy.random.random_sample(nSamples)*numpy.radians(50.0)
-        theta = numpy.random.random_sample(nSamples)*2.0*numpy.pi
-        ra_in = numpy.radians(raCenter) + rr*numpy.cos(theta)
-        dec_in = numpy.radians(decCenter) + rr*numpy.sin(theta)
+        rr = np.random.random_sample(nSamples)*np.radians(50.0)
+        theta = np.random.random_sample(nSamples)*2.0*np.pi
+        ra_in = np.radians(raCenter) + rr*np.cos(theta)
+        dec_in = np.radians(decCenter) + rr*np.sin(theta)
 
-        xx_in = numpy.cos(dec_in)*numpy.cos(ra_in)
-        yy_in = numpy.cos(dec_in)*numpy.sin(ra_in)
-        zz_in = numpy.sin(dec_in)
+        xx_in = np.cos(dec_in)*np.cos(ra_in)
+        yy_in = np.cos(dec_in)*np.sin(ra_in)
+        zz_in = np.sin(dec_in)
 
         for includeRefraction in [True, False]:
             for wavelength in (0.5, 0.3, 0.7):
@@ -826,13 +826,13 @@ class astrometryUnitTest(unittest.TestCase):
                                                       includeRefraction=includeRefraction)
 
 
-                xx_out = numpy.cos(dec_out)*numpy.cos(ra_out)
-                yy_out = numpy.cos(dec_out)*numpy.sin(ra_out)
-                zz_out = numpy.sin(dec_out)
+                xx_out = np.cos(dec_out)*np.cos(ra_out)
+                yy_out = np.cos(dec_out)*np.sin(ra_out)
+                zz_out = np.sin(dec_out)
 
-                distance = numpy.sqrt(numpy.power(xx_in-xx_out,2) +
-                                      numpy.power(yy_in-yy_out,2) +
-                                      numpy.power(zz_in-zz_out,2))
+                distance = np.sqrt(np.power(xx_in-xx_out,2) +
+                                      np.power(yy_in-yy_out,2) +
+                                      np.power(zz_in-zz_out,2))
 
                 self.assertLess(distance.max(), 1.0e-12)
 
@@ -841,9 +841,9 @@ class astrometryUnitTest(unittest.TestCase):
         """
         Test that _appGeoFromObserved raises exceptions where expected
         """
-        numpy.random.seed(12)
-        ra_in = numpy.random.random_sample(10)*2.0*numpy.pi
-        dec_in = (numpy.random.random_sample(10)-0.5)*numpy.pi
+        np.random.seed(12)
+        ra_in = np.random.random_sample(10)*2.0*np.pi
+        dec_in = (np.random.random_sample(10)-0.5)*np.pi
 
         with self.assertRaises(RuntimeError) as context:
             ra_out, dec_out = _appGeoFromObserved(ra_in, dec_in)
@@ -881,7 +881,7 @@ class astrometryUnitTest(unittest.TestCase):
     def testApplyRefraction(self):
         coeffs=refractionCoefficients(wavelength=5000.0, site=self.obs_metadata.site)
 
-        output=applyRefraction(0.25*numpy.pi,coeffs[0],coeffs[1])
+        output=applyRefraction(0.25*np.pi,coeffs[0],coeffs[1])
 
         self.assertAlmostEqual(output,7.851689251070859132e-01,6)
 

--- a/tests/testCodeUtilities.py
+++ b/tests/testCodeUtilities.py
@@ -1,0 +1,62 @@
+from __future__ import with_statement
+import unittest
+import numpy as np
+import lsst.utils.tests as utilsTests
+from lsst.sims.utils.CodeUtilities import _validate_inputs
+
+
+class CodeUtilsTest(unittest.TestCase):
+
+    def test_validate_inputs(self):
+        """
+        test that _validate_inputs returns expected values
+        """
+
+        # test that it correctly identifies numpy array inputs
+        self.assertTrue(_validate_inputs([np.array([1, 2]),
+                                          np.array([3, 4])],
+                                         ['a', 'b'],
+                                         'dummy_method'))
+
+        # test that it correctly identifies inputs that are numbers
+        self.assertFalse(_validate_inputs([1, 2, 3], ['a', 'b', 'c'], 'dummy'))
+
+        # test that the correct exception is raised when you pass in
+        # a number a numpy array
+        with self.assertRaises(RuntimeError) as ee:
+            _validate_inputs([1, np.array([2, 3])], ['a', 'b'], 'dummy')
+
+        self.assertIn("and the same type", ee.exception.args[0])
+
+        # test that the correct exception is raised when you pass in
+        # numpy arrays of different length
+        with self.assertRaises(RuntimeError) as ee:
+            _validate_inputs([np.array([1, 2]), np.array([1, 2, 3])],
+                             ['a', 'b'], 'dummy')
+
+        self.assertIn("same length", ee.exception.args[0])
+
+        # test that an exception is raised if lists (rather than numpy
+        # arrays) are passed in
+        with self.assertRaises(RuntimeError) as ee:
+            _validate_inputs([[1, 2], [3, 4]], ['a', 'b'], 'dummy')
+
+        self.assertIn("either a number or a numpy array",
+                      ee.exception.args[0])
+
+
+def suite():
+    """Returns a suite containing all the test cases in this module."""
+    utilsTests.init()
+    suites = []
+    suites += unittest.makeSuite(CodeUtilsTest)
+
+    return unittest.TestSuite(suites)
+
+
+def run(shouldExit=False):
+    """Run the tests"""
+    utilsTests.run(suite(), shouldExit)
+
+if __name__ == "__main__":
+    run(True)

--- a/tests/testCompoundCoordinateTransformations.py
+++ b/tests/testCompoundCoordinateTransformations.py
@@ -205,8 +205,19 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
                 ra_in, dec_in = utils.raDecFromAltAz(alt_in, az_in, obs)
 
+                self.assertIsInstance(ra_in, np.ndarray)
+                self.assertIsInstance(dec_in, np.ndarray)
+
                 self.assertFalse(np.isnan(ra_in).any())
                 self.assertFalse(np.isnan(dec_in).any())
+
+                # test that passing them in one at a time gives the same answer
+                for ix in range(len(alt_in)):
+                    ra_f, dec_f = utils.raDecFromAltAz(alt_in[ix], az_in[ix], obs)
+                    self.assertIsInstance(ra_f, np.float)
+                    self.assertIsInstance(dec_f, np.float)
+                    self.assertAlmostEqual(ra_f, ra_in[ix], 12)
+                    self.assertAlmostEqual(dec_f, dec_in[ix], 12)
 
                 alt_out, az_out, pa_out = utils.altAzPaFromRaDec(ra_in, dec_in, obs)
 

--- a/tests/testCompoundCoordinateTransformations.py
+++ b/tests/testCompoundCoordinateTransformations.py
@@ -1,8 +1,8 @@
 import unittest
 import numpy as np
-import palpy
 import lsst.utils.tests as utilsTests
 import lsst.sims.utils as utils
+
 
 def controlAltAzFromRaDec(raRad_in, decRad_in, longRad, latRad, mjd):
     """
@@ -29,7 +29,9 @@ def controlAltAzFromRaDec(raRad_in, decRad_in, longRad, latRad, mjd):
     see: http://www.stargazing.net/kepler/altaz.html#twig04
     """
     obs = utils.ObservationMetaData(mjd=utils.ModifiedJulianDate(UTC=mjd),
-              site=utils.Site(longitude=np.degrees(longRad), latitude=np.degrees(latRad), name='LSST'))
+                                    site=utils.Site(longitude=np.degrees(longRad),
+                                                    latitude=np.degrees(latRad),
+                                                    name='LSST'))
 
     if hasattr(raRad_in, '__len__'):
         raRad, decRad = utils._observedFromICRS(raRad_in, decRad_in, obs_metadata=obs,
@@ -45,10 +47,10 @@ def controlAltAzFromRaDec(raRad_in, decRad_in, longRad, latRad, mjd):
     sinDec = np.sin(decRad)
     cosLat = np.cos(latRad)
     sinLat = np.sin(latRad)
-    sinAlt = sinDec*sinLat+np.cos(decRad)*cosLat*np.cos(haRad)
+    sinAlt = sinDec*sinLat + np.cos(decRad)*cosLat*np.cos(haRad)
     altRad = np.arcsin(sinAlt)
     azRad = np.arccos((sinDec - sinAlt*sinLat)/(np.cos(altRad)*cosLat))
-    azRadOut = np.where(np.sin(haRad)>=0.0, 2.0*np.pi-azRad, azRad)
+    azRadOut = np.where(np.sin(haRad) >= 0.0, 2.0*np.pi - azRad, azRad)
     return altRad, azRadOut
 
 
@@ -56,10 +58,8 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(32)
-        ntests = 100
         self.mjd = 57087.0
         self.tolerance = 1.0e-5
-
 
     def testExceptions(self):
         """
@@ -75,24 +75,23 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
         self.assertRaises(RuntimeError, utils._altAzPaFromRaDec, raList, decFloat, obs)
         self.assertRaises(RuntimeError, utils._altAzPaFromRaDec, raFloat, decList, obs)
-        ans = utils._altAzPaFromRaDec(raFloat, decFloat, obs)
-        ans = utils._altAzPaFromRaDec(raList, decList, obs)
+        utils._altAzPaFromRaDec(raFloat, decFloat, obs)
+        utils._altAzPaFromRaDec(raList, decList, obs)
 
         self.assertRaises(RuntimeError, utils._raDecFromAltAz, raList, decFloat, obs)
         self.assertRaises(RuntimeError, utils._raDecFromAltAz, raFloat, decList, obs)
-        ans = utils._raDecFromAltAz(raFloat, decFloat, obs)
-        ans = utils._raDecFromAltAz(raList, decList, obs)
+        utils._raDecFromAltAz(raFloat, decFloat, obs)
+        utils._raDecFromAltAz(raList, decList, obs)
 
         self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raList, decFloat, obs)
         self.assertRaises(RuntimeError, utils.altAzPaFromRaDec, raFloat, decList, obs)
-        ans = utils.altAzPaFromRaDec(raFloat, decFloat, obs)
-        ans = utils.altAzPaFromRaDec(raList, decList, obs)
+        utils.altAzPaFromRaDec(raFloat, decFloat, obs)
+        utils.altAzPaFromRaDec(raList, decList, obs)
 
         self.assertRaises(RuntimeError, utils.raDecFromAltAz, raList, decFloat, obs)
         self.assertRaises(RuntimeError, utils.raDecFromAltAz, raFloat, decList, obs)
-        ans = utils.raDecFromAltAz(raFloat, decFloat, obs)
-        ans = utils.raDecFromAltAz(raList, decList, obs)
-
+        utils.raDecFromAltAz(raFloat, decFloat, obs)
+        utils.raDecFromAltAz(raList, decList, obs)
 
     def test_raDecFromAltAz(self):
         """
@@ -125,25 +124,25 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
         ra_app_list = []
         dec_app_list = []
 
-        longitude_list.append(np.radians(-22.0-33.0/60.0))
-        latitude_list.append(np.radians(11.0+45.0/60.0))
-        mjd_list.append(2457364.958333-2400000.5) # 8 December 2015 11:00 UTC
+        longitude_list.append(np.radians(-22.0 - 33.0/60.0))
+        latitude_list.append(np.radians(11.0 + 45.0/60.0))
+        mjd_list.append(2457364.958333 - 2400000.5)  # 8 December 2015 11:00 UTC
         alt_list.append(np.radians(41.1))
         az_list.append(np.radians(134.7))
         ra_app_list.append(16.0*hours + 59.0*minutes + 16.665*seconds)
         dec_app_list.append(np.radians(-22.0 - 42.0/60.0 - 2.94/3600.0))
 
-        longitude_list.append(np.radians(-22.0-33.0/60.0))
-        latitude_list.append(np.radians(11.0+45.0/60.0))
-        mjd_list.append(2457368.958333-2400000.5) # 12 December 2015 11:00 UTC
+        longitude_list.append(np.radians(-22.0 - 33.0/60.0))
+        latitude_list.append(np.radians(11.0 + 45.0/60.0))
+        mjd_list.append(2457368.958333 - 2400000.5)  # 12 December 2015 11:00 UTC
         alt_list.append(np.radians(40.5))
         az_list.append(np.radians(134.7))
-        ra_app_list.append(17.0*hours + 16.0*minutes +51.649*seconds)
+        ra_app_list.append(17.0*hours + 16.0*minutes + 51.649*seconds)
         dec_app_list.append(np.radians(-23.0-3/60.0-50.35/3600.0))
 
         longitude_list.append(np.radians(145.0 + 23.0/60.0))
-        latitude_list.append(np.radians(-64.0-5.0/60.0))
-        mjd_list.append(2456727.583333-2400000.5) # 11 March 2014, 02:00 UTC
+        latitude_list.append(np.radians(-64.0 - 5.0/60.0))
+        mjd_list.append(2456727.583333-2400000.5)  # 11 March 2014, 02:00 UTC
         alt_list.append(np.radians(29.5))
         az_list.append(np.radians(8.2))
         ra_app_list.append(23.0*hours + 24.0*minutes + 46.634*seconds)
@@ -151,7 +150,7 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
         longitude_list.append(np.radians(145.0 + 23.0/60.0))
         latitude_list.append(np.radians(-64.0-5.0/60.0))
-        mjd_list.append(2456731.583333-2400000.5) # 15 March 2014, 02:00 UTC
+        mjd_list.append(2456731.583333 - 2400000.5)  # 15 March 2014, 02:00 UTC
         alt_list.append(np.radians(28.0))
         az_list.append(np.radians(7.8))
         ra_app_list.append(23.0*hours + 39.0*minutes + 27.695*seconds)
@@ -165,17 +164,15 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
                                                             latitude=np.degrees(latitude), name='LSST'),
                                             mjd=utils.ModifiedJulianDate(UTC=mjd))
 
-
             ra_icrs, dec_icrs = utils._raDecFromAltAz(alt, az, obs)
             ra_test, dec_test = utils._appGeoFromICRS(ra_icrs, dec_icrs, mjd=obs.mjd)
 
             distance = np.degrees(utils.haversine(ra_app, dec_app, ra_test, dec_test))
-            self.assertLess(distance, 0.1) # since that is all the precision we have in the alt, az
-                                           # data taken from the USNO
+            self.assertLess(distance, 0.1)  # since that is all the precision we have in the alt, az
+                                            # data taken from the USNO
+
             correction = np.degrees(utils.haversine(ra_test, dec_test, ra_icrs, dec_icrs))
             self.assertLess(distance, correction)
-
-
 
     def testAltAzRADecRoundTrip(self):
         """
@@ -198,7 +195,8 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
         for lon in (0.0, 90.0, 135.0):
             for lat in (60.0, 30.0, -60.0, -30.0):
 
-                obs = utils.ObservationMetaData(mjd=mjd, site=utils.Site(longitude=lon, latitude=lat, name='LSST'))
+                obs = utils.ObservationMetaData(mjd=mjd,
+                                                site=utils.Site(longitude=lon, latitude=lat, name='LSST'))
 
                 ra_in, dec_in = utils.raDecFromAltAz(alt_in, az_in, obs)
 
@@ -222,9 +220,10 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
                 for alt_c, az_c, alt_t, az_t in \
                     zip(np.radians(alt_in), np.radians(az_in), np.radians(alt_out), np.radians(az_out)):
-                    distance = utils.arcsecFromRadians(utils.haversine(az_c, alt_c, az_t, alt_t))
-                    self.assertLess(distance, 0.2) # not sure why 0.2 arcsec is the limiting precision of this test
 
+                    distance = utils.arcsecFromRadians(utils.haversine(az_c, alt_c, az_t, alt_t))
+                    self.assertLess(distance, 0.2)
+                    # not sure why 0.2 arcsec is the limiting precision of this test
 
     def testAltAzFromRaDec(self):
         """
@@ -237,15 +236,17 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
         dec = (np.random.sample(nSamples)-0.5)*np.pi
         lon_rad = 1.467
         lat_rad = -0.234
-        controlAlt, controlAz = controlAltAzFromRaDec(ra, dec, \
-                                                     lon_rad, lat_rad, \
-                                                     self.mjd)
+        controlAlt, controlAz = controlAltAzFromRaDec(ra, dec,
+                                                      lon_rad, lat_rad,
+                                                      self.mjd)
 
         obs = utils.ObservationMetaData(mjd=utils.ModifiedJulianDate(UTC=self.mjd),
-                                        site=utils.Site(longitude=np.degrees(lon_rad), latitude=np.degrees(lat_rad), name='LSST'))
+                                        site=utils.Site(longitude=np.degrees(lon_rad),
+                                                        latitude=np.degrees(lat_rad),
+                                                        name='LSST'))
 
-        #verify parallactic angle against an expression from
-        #http://www.astro.washington.edu/groups/APO/Mirror.Motions/Feb.2000.Image.Jumps/report.html#Image%20motion%20directions
+        # verify parallactic angle against an expression from
+        # http://www.astro.washington.edu/groups/APO/Mirror.Motions/Feb.2000.Image.Jumps/report.html#Image%20motion%20directions
         #
         ra_obs, dec_obs = utils._observedFromICRS(ra, dec, obs_metadata=obs, epoch=2000.0,
                                                   includeRefraction=True)
@@ -259,9 +260,8 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
         distance = utils.arcsecFromRadians(utils.haversine(controlAz, controlAlt, testAz, testAlt))
         self.assertLess(distance.max(), 0.0001)
 
-
-        #test non-vectorized version
-        for r,d in zip(ra, dec):
+        # test non-vectorized version
+        for r, d in zip(ra, dec):
             controlAlt, controlAz = controlAltAzFromRaDec(r, d, lon_rad, lat_rad, self.mjd)
             testAlt, testAz, testPa = utils._altAzPaFromRaDec(r, d, obs)
             lmst, last = utils.calcLmstLast(self.mjd, lon_rad)
@@ -274,7 +274,6 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
             self.assertLess(np.abs(np.sin(testPa) - controlSinPa), self.tolerance)
 
 
-
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()
@@ -282,6 +281,7 @@ def suite():
     suites += unittest.makeSuite(CompoundCoordinateTransformationsTests)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit=False):
     """Run the tests"""

--- a/tests/testCompoundCoordinateTransformations.py
+++ b/tests/testCompoundCoordinateTransformations.py
@@ -35,10 +35,8 @@ def controlAltAzFromRaDec(raRad_in, decRad_in, longRad, latRad, mjd):
         raRad, decRad = utils._observedFromICRS(raRad_in, decRad_in, obs_metadata=obs,
                                                 epoch=2000.0, includeRefraction=True)
     else:
-        raRad_temp, decRad_temp = utils._observedFromICRS(np.array([raRad_in]), np.array([decRad_in]),
-                                                          obs_metadata=obs, epoch=2000.0, includeRefraction=True)
-        raRad = raRad_temp[0]
-        decRad = decRad_temp[0]
+        raRad, decRad = utils._observedFromICRS(raRad_in, decRad_in,
+                                                obs_metadata=obs, epoch=2000.0, includeRefraction=True)
 
     lst = utils.calcLmstLast(mjd, longRad)
     last = lst[1]
@@ -169,13 +167,12 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
 
 
             ra_icrs, dec_icrs = utils._raDecFromAltAz(alt, az, obs)
-            ra_test, dec_test = utils._appGeoFromICRS(np.array([ra_icrs]), np.array([dec_icrs]),
-                                                      mjd=obs.mjd)
+            ra_test, dec_test = utils._appGeoFromICRS(ra_icrs, dec_icrs, mjd=obs.mjd)
 
-            distance = np.degrees(utils.haversine(ra_app, dec_app, ra_test[0], dec_test[0]))
+            distance = np.degrees(utils.haversine(ra_app, dec_app, ra_test, dec_test))
             self.assertLess(distance, 0.1) # since that is all the precision we have in the alt, az
                                            # data taken from the USNO
-            correction = np.degrees(utils.haversine(ra_test[0], dec_test[0], ra_icrs, dec_icrs))
+            correction = np.degrees(utils.haversine(ra_test, dec_test, ra_icrs, dec_icrs))
             self.assertLess(distance, correction)
 
 
@@ -268,9 +265,9 @@ class CompoundCoordinateTransformationsTests(unittest.TestCase):
             controlAlt, controlAz = controlAltAzFromRaDec(r, d, lon_rad, lat_rad, self.mjd)
             testAlt, testAz, testPa = utils._altAzPaFromRaDec(r, d, obs)
             lmst, last = utils.calcLmstLast(self.mjd, lon_rad)
-            r_obs, dec_obs = utils._observedFromICRS(np.array([r]), np.array([d]), obs_metadata=obs,
+            r_obs, dec_obs = utils._observedFromICRS(r, d, obs_metadata=obs,
                                                      epoch=2000.0, includeRefraction=True)
-            hourAngle = np.radians(last*15.0) - r_obs[0]
+            hourAngle = np.radians(last*15.0) - r_obs
             controlSinPa = np.sin(hourAngle)*np.cos(lat_rad)/np.cos(controlAlt)
             self.assertLess(np.abs(testAz - controlAz), self.tolerance)
             self.assertLess(np.abs(testAlt - controlAlt), self.tolerance)

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -282,6 +282,16 @@ class testCoordinateTransformations(unittest.TestCase):
         for pp, oo in zip(points, outPoints):
             np.testing.assert_array_almost_equal(pp, oo, decimal=6)
 
+        # test passing in arguments as floats
+        for ix, (ll, bb) in enumerate(zip(lon, lat)):
+            xyz = utils.cartesianFromSpherical(ll, bb)
+            self.assertIsInstance(xyz[0], np.float)
+            self.assertIsInstance(xyz[1], np.float)
+            self.assertIsInstance(xyz[2], np.float)
+            self.assertAlmostEqual(xyz[0], outPoints[ix][0], 12)
+            self.assertAlmostEqual(xyz[1], outPoints[ix][1], 12)
+            self.assertAlmostEqual(xyz[2], outPoints[ix][2], 12)
+
 
     def testHaversine(self):
         arg1 = 7.853981633974482790e-01

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -275,13 +275,13 @@ class testCoordinateTransformations(unittest.TestCase):
 
             points.append(vv)
 
-
         points = np.array(points)
         lon, lat = utils.sphericalFromCartesian(points)
         outPoints = utils.cartesianFromSpherical(np.array(lon), np.array(lat))
 
         for pp, oo in zip(points, outPoints):
             np.testing.assert_array_almost_equal(pp, oo, decimal=6)
+
 
     def testHaversine(self):
         arg1 = 7.853981633974482790e-01

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -167,14 +167,28 @@ class testCoordinateTransformations(unittest.TestCase):
         ra[2]=7.740864769302191473e-01
         dec[2]=2.758053025017753179e-01
 
-        output=utils._galacticFromEquatorial(ra,dec)
+        glon, glat = utils._galacticFromEquatorial(ra,dec)
 
-        self.assertAlmostEqual(output[0][0],3.452036693523627964e+00,6)
-        self.assertAlmostEqual(output[1][0],8.559512505657201897e-01,6)
-        self.assertAlmostEqual(output[0][1],2.455968474619387720e+00,6)
-        self.assertAlmostEqual(output[1][1],3.158563770667878468e-02,6)
-        self.assertAlmostEqual(output[0][2],2.829585540991265358e+00,6)
-        self.assertAlmostEqual(output[1][2],-6.510790587552289788e-01,6)
+        self.assertIsInstance(glon, np.ndarray)
+        self.assertIsInstance(glat, np.ndarray)
+
+        self.assertAlmostEqual(glon[0],3.452036693523627964e+00,6)
+        self.assertAlmostEqual(glat[0],8.559512505657201897e-01,6)
+        self.assertAlmostEqual(glon[1],2.455968474619387720e+00,6)
+        self.assertAlmostEqual(glat[1],3.158563770667878468e-02,6)
+        self.assertAlmostEqual(glon[2],2.829585540991265358e+00,6)
+        self.assertAlmostEqual(glat[2],-6.510790587552289788e-01,6)
+
+        # test passing in floats as args
+        for ix, (rr, dd) in enumerate(zip(ra, dec)):
+            gl, gb = utils._galacticFromEquatorial(rr, dd)
+            self.assertIsInstance(rr, np.float)
+            self.assertIsInstance(dd, np.float)
+            self.assertIsInstance(gl, np.float)
+            self.assertIsInstance(gb, np.float)
+            self.assertAlmostEqual(gl, glon[ix], 10)
+            self.assertAlmostEqual(gb, glat[ix], 10)
+
 
     def test_equatorialFromGalactic(self):
 

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -115,6 +115,8 @@ class testCoordinateTransformations(unittest.TestCase):
 
         gmst, gast = utils.calcGmstGast(self.mjd)
         ll = [1.2, 2.2]
+
+        # test passing a float for longitude and a numpy array for mjd
         for longitude in ll:
             hours = numpy.degrees(longitude)/15.0
             if hours > 24.0:
@@ -126,8 +128,10 @@ class testCoordinateTransformations(unittest.TestCase):
             testLmst, testLast = utils.calcLmstLast(self.mjd, longitude)
             self.assertTrue(numpy.abs(testLmst - controlLmst).max() < self.tolerance)
             self.assertTrue(numpy.abs(testLast - controlLast).max() < self.tolerance)
+            self.assertIsInstance(testLmst, numpy.ndarray)
+            self.assertIsInstance(testLast, numpy.ndarray)
 
-        #test non-vectorized version
+        # test passing two floats
         for longitude in ll:
             for mm in self.mjd:
                 gmst, gast = utils.calcGmstGast(mm)
@@ -141,7 +145,18 @@ class testCoordinateTransformations(unittest.TestCase):
                 testLmst, testLast = utils.calcLmstLast(mm, longitude)
                 self.assertTrue(numpy.abs(testLmst - controlLmst) < self.tolerance)
                 self.assertTrue(numpy.abs(testLast - controlLast) < self.tolerance)
+                self.assertIsInstance(testLmst, numpy.float)
+                self.assertIsInstance(testLast, numpy.float)
 
+        # test passing two numpy arrays
+        ll = numpy.random.random_sample(len(self.mjd))*2.0*numpy.pi
+        testLmst, testLast = utils.calcLmstLast(self.mjd, ll)
+        self.assertIsInstance(testLmst, numpy.ndarray)
+        self.assertIsInstance(testLast, numpy.ndarray)
+        for ix, (longitude, mm) in enumerate(zip(ll, self.mjd)):
+            controlLmst, controlLast = utils.calcLmstLast(mm, longitude)
+            self.assertAlmostEqual(controlLmst, testLmst[ix], 10)
+            self.assertAlmostEqual(controlLast, testLast[ix], 10)
 
 
     def test_galacticFromEquatorial(self):

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -225,21 +225,6 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(dd, dec[ix], 10)
 
 
-    def testCartesianFromSpherical(self):
-        arg1=2.19911485751
-        arg2=5.96902604182
-        output=utils.cartesianFromSpherical(arg1,arg2)
-
-        vv=np.zeros((3),dtype=float)
-        vv[0]=np.cos(arg2)*np.cos(arg1)
-        vv[1]=np.cos(arg2)*np.sin(arg1)
-        vv[2]=np.sin(arg2)
-
-        self.assertAlmostEqual(output[0],vv[0],7)
-        self.assertAlmostEqual(output[1],vv[1],7)
-        self.assertAlmostEqual(output[2],vv[2],7)
-
-
     def testSphericalFromCartesian(self):
         """
         Note that xyz[i][j] is the ith component of the jth vector

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -1,10 +1,7 @@
-import os
 import numpy as np
 import unittest
-import palpy as palpy
 import lsst.utils.tests as utilsTests
 import lsst.sims.utils as utils
-from lsst.sims.utils import Site
 
 
 def controlEquationOfEquinoxes(mjd):
@@ -25,8 +22,9 @@ def controlEquationOfEquinoxes(mjd):
     epsilonDegrees = 23.4393 - 0.0000004*D
     return (deltaPsiHours/24.0)*2.0*np.pi*np.cos(np.radians(epsilonDegrees))
 
+
 def controlCalcGmstGast(mjd):
-    #From http://aa.usno.navy.mil/faq/docs/GAST.php Nov. 9 2013
+    # From http://aa.usno.navy.mil/faq/docs/GAST.php Nov. 9 2013
     mjdConv = 2400000.5
     jd2000 = 2451545.0
     mjd_o = np.floor(mjd)
@@ -41,6 +39,7 @@ def controlCalcGmstGast(mjd):
     gmst %= 24.
     gast %= 24.
     return gmst, gast
+
 
 class testCoordinateTransformations(unittest.TestCase):
 
@@ -66,22 +65,21 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertRaises(RuntimeError, utils.calcLmstLast, list(mjd2), longArr)
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjd2, list(longArr))
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
-        ans = utils.calcLmstLast(mjd2, longFloat)
-        ans = utils.calcLmstLast(mjdFloat, longFloat)
-        ans = utils.calcLmstLast(mjd2, longArr)
-
+        utils.calcLmstLast(mjd2, longFloat)
+        utils.calcLmstLast(mjdFloat, longFloat)
+        utils.calcLmstLast(mjd2, longArr)
 
     def testEquationOfEquinoxes(self):
         """
         Test equation of equninoxes calculation
         """
 
-        #test vectorized version
+        # test vectorized version
         control = controlEquationOfEquinoxes(self.mjd)
         test = utils.equationOfEquinoxes(self.mjd)
         self.assertTrue(np.abs(test-control).max() < self.tolerance)
 
-        #test non-vectorized version
+        # test non-vectorized version
         for mm in self.mjd:
             control = controlEquationOfEquinoxes(mm)
             test = utils.equationOfEquinoxes(mm)
@@ -97,7 +95,7 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertTrue(np.abs(testGmst - controlGmst).max() < self.tolerance)
         self.assertTrue(np.abs(testGast - controlGast).max() < self.tolerance)
 
-        #test non-vectorized version
+        # test non-vectorized version
         for mm in self.mjd:
             controlGmst, controlGast = controlCalcGmstGast(mm)
             testGmst, testGast = utils.calcGmstGast(mm)
@@ -154,30 +152,29 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(controlLmst, testLmst[ix], 10)
             self.assertAlmostEqual(controlLast, testLast[ix], 10)
 
-
     def test_galacticFromEquatorial(self):
 
-        ra=np.zeros((3),dtype=float)
-        dec=np.zeros((3),dtype=float)
+        ra = np.zeros((3), dtype=float)
+        dec = np.zeros((3), dtype=float)
 
-        ra[0]=2.549091039839124218e+00
-        dec[0]=5.198752733024248895e-01
-        ra[1]=8.693375673649429425e-01
-        dec[1]=1.038086165642298164e+00
-        ra[2]=7.740864769302191473e-01
-        dec[2]=2.758053025017753179e-01
+        ra[0] = 2.549091039839124218e+00
+        dec[0] = 5.198752733024248895e-01
+        ra[1] = 8.693375673649429425e-01
+        dec[1] = 1.038086165642298164e+00
+        ra[2] = 7.740864769302191473e-01
+        dec[2] = 2.758053025017753179e-01
 
-        glon, glat = utils._galacticFromEquatorial(ra,dec)
+        glon, glat = utils._galacticFromEquatorial(ra, dec)
 
         self.assertIsInstance(glon, np.ndarray)
         self.assertIsInstance(glat, np.ndarray)
 
-        self.assertAlmostEqual(glon[0],3.452036693523627964e+00,6)
-        self.assertAlmostEqual(glat[0],8.559512505657201897e-01,6)
-        self.assertAlmostEqual(glon[1],2.455968474619387720e+00,6)
-        self.assertAlmostEqual(glat[1],3.158563770667878468e-02,6)
-        self.assertAlmostEqual(glon[2],2.829585540991265358e+00,6)
-        self.assertAlmostEqual(glat[2],-6.510790587552289788e-01,6)
+        self.assertAlmostEqual(glon[0], 3.452036693523627964e+00, 6)
+        self.assertAlmostEqual(glat[0], 8.559512505657201897e-01, 6)
+        self.assertAlmostEqual(glon[1], 2.455968474619387720e+00, 6)
+        self.assertAlmostEqual(glat[1], 3.158563770667878468e-02, 6)
+        self.assertAlmostEqual(glon[2], 2.829585540991265358e+00, 6)
+        self.assertAlmostEqual(glat[2], -6.510790587552289788e-01, 6)
 
         # test passing in floats as args
         for ix, (rr, dd) in enumerate(zip(ra, dec)):
@@ -189,30 +186,29 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(gl, glon[ix], 10)
             self.assertAlmostEqual(gb, glat[ix], 10)
 
-
     def test_equatorialFromGalactic(self):
 
-        lon=np.zeros((3),dtype=float)
-        lat=np.zeros((3),dtype=float)
+        lon = np.zeros((3), dtype=float)
+        lat = np.zeros((3), dtype=float)
 
-        lon[0]=3.452036693523627964e+00
-        lat[0]=8.559512505657201897e-01
-        lon[1]=2.455968474619387720e+00
-        lat[1]=3.158563770667878468e-02
-        lon[2]=2.829585540991265358e+00
-        lat[2]=-6.510790587552289788e-01
+        lon[0] = 3.452036693523627964e+00
+        lat[0] = 8.559512505657201897e-01
+        lon[1] = 2.455968474619387720e+00
+        lat[1] = 3.158563770667878468e-02
+        lon[2] = 2.829585540991265358e+00
+        lat[2] = -6.510790587552289788e-01
 
-        ra, dec = utils._equatorialFromGalactic(lon,lat)
+        ra, dec = utils._equatorialFromGalactic(lon, lat)
 
         self.assertIsInstance(ra, np.ndarray)
         self.assertIsInstance(dec, np.ndarray)
 
-        self.assertAlmostEqual(ra[0],2.549091039839124218e+00,6)
-        self.assertAlmostEqual(dec[0],5.198752733024248895e-01,6)
-        self.assertAlmostEqual(ra[1],8.693375673649429425e-01,6)
-        self.assertAlmostEqual(dec[1],1.038086165642298164e+00,6)
-        self.assertAlmostEqual(ra[2],7.740864769302191473e-01,6)
-        self.assertAlmostEqual(dec[2],2.758053025017753179e-01,6)
+        self.assertAlmostEqual(ra[0], 2.549091039839124218e+00, 6)
+        self.assertAlmostEqual(dec[0], 5.198752733024248895e-01, 6)
+        self.assertAlmostEqual(ra[1], 8.693375673649429425e-01, 6)
+        self.assertAlmostEqual(dec[1], 1.038086165642298164e+00, 6)
+        self.assertAlmostEqual(ra[2], 7.740864769302191473e-01, 6)
+        self.assertAlmostEqual(dec[2], 2.758053025017753179e-01, 6)
 
         # test passing in floats as args
         for ix, (ll, bb) in enumerate(zip(lon, lat)):
@@ -223,7 +219,6 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertIsInstance(dd, np.float)
             self.assertAlmostEqual(rr, ra[ix], 10)
             self.assertAlmostEqual(dd, dec[ix], 10)
-
 
     def testSphericalFromCartesian(self):
         """
@@ -261,7 +256,6 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(np.cos(lat), np.cos(th), 5)
             self.assertAlmostEqual(np.sin(lat), np.sin(th), 5)
 
-
     def testCartesianFromSpherical(self):
         np.random.seed(42)
         nsamples = 10
@@ -293,39 +287,36 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(xyz[1], outPoints[ix][1], 12)
             self.assertAlmostEqual(xyz[2], outPoints[ix][2], 12)
 
-
     def testHaversine(self):
         arg1 = 7.853981633974482790e-01
         arg2 = 3.769911184307751517e-01
         arg3 = 5.026548245743668986e+00
         arg4 = -6.283185307179586232e-01
 
-        output=utils.haversine(arg1,arg2,arg3,arg4)
+        output = utils.haversine(arg1, arg2, arg3, arg4)
 
-        self.assertAlmostEqual(output,2.162615946398791955e+00,10)
-
-
+        self.assertAlmostEqual(output, 2.162615946398791955e+00, 10)
 
     def testRotationMatrixFromVectors(self):
-        v1=np.zeros((3),dtype=float)
-        v2=np.zeros((3),dtype=float)
-        v3=np.zeros((3),dtype=float)
+        v1 = np.zeros((3), dtype=float)
+        v2 = np.zeros((3), dtype=float)
+        v3 = np.zeros((3), dtype=float)
 
-        v1[0]=-3.044619987218469825e-01
-        v2[0]=5.982190522311925385e-01
-        v1[1]=-5.473550908956383854e-01
-        v2[1]=-5.573565912346714057e-01
-        v1[2]=7.795545496018386755e-01
-        v2[2]=-5.757495946632366079e-01
+        v1[0] = -3.044619987218469825e-01
+        v2[0] = 5.982190522311925385e-01
+        v1[1] = -5.473550908956383854e-01
+        v2[1] = -5.573565912346714057e-01
+        v1[2] = 7.795545496018386755e-01
+        v2[2] = -5.757495946632366079e-01
 
-        output=utils.rotationMatrixFromVectors(v1,v2)
+        output = utils.rotationMatrixFromVectors(v1, v2)
 
         for i in range(3):
             for j in range(3):
-                v3[i]+=output[i][j]*v1[j]
+                v3[i] += output[i][j]*v1[j]
 
         for i in range(3):
-            self.assertAlmostEqual(v3[i],v2[i],7)
+            self.assertAlmostEqual(v3[i], v2[i], 7)
 
         v1 = np.array([1.0, 1.0, 1.0])
         self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v1, v2)
@@ -339,6 +330,7 @@ def suite():
     suites += unittest.makeSuite(testCoordinateTransformations)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit=False):
     """Run the tests"""

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -67,6 +67,9 @@ class testCoordinateTransformations(unittest.TestCase):
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
         utils.calcLmstLast(mjd2, longFloat)
         utils.calcLmstLast(mjdFloat, longFloat)
+        utils.calcLmstLast(int(mjdFloat), longFloat)
+        utils.calcLmstLast(mjdFloat, int(longFloat))
+        utils.calcLmstLast(int(mjdFloat), int(longFloat))
         utils.calcLmstLast(mjd2, longArr)
 
     def testEquationOfEquinoxes(self):

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -278,7 +278,7 @@ class testCoordinateTransformations(unittest.TestCase):
 
         points = np.array(points)
         lon, lat = utils.sphericalFromCartesian(points)
-        outPoints = utils.cartesianFromSpherical(np.array(lon), np.array(lat))
+        outPoints = utils.cartesianFromSpherical(lon, lat)
 
         for pp, oo in zip(points, outPoints):
             np.testing.assert_array_almost_equal(pp, oo, decimal=6)

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -253,6 +253,7 @@ class testCoordinateTransformations(unittest.TestCase):
             self.assertAlmostEqual(np.cos(lat[ix]), np.cos(theta[ix]), 5)
             self.assertAlmostEqual(np.sin(lat[ix]), np.sin(theta[ix]), 5)
 
+        # test passing in the points one at a time
         for pp, th, ph in zip(points, theta, phi):
             lon, lat = utils.sphericalFromCartesian(pp)
             self.assertAlmostEqual(np.cos(lon), np.cos(ph), 5)

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -59,20 +59,24 @@ class testCoordinateTransformations(unittest.TestCase):
         mjd3 = numpy.array([53000.0, 53000.0, 54000.0])
 
         longFloat = 1.2
-        longList = numpy.array([1.2, 1.4])
+        longArr = numpy.array([1.2, 1.4])
         latFloat = 0.5
-        latList = numpy.array([0.5, 0.6])
+        latArr = numpy.array([0.5, 0.6])
 
         raFloat = 1.1
-        raList = numpy.array([0.2, 0.3])
+        raArr = numpy.array([0.2, 0.3])
 
         decFloat = 1.1
-        decList = numpy.array([0.2, 0.3])
+        decArr = numpy.array([0.2, 0.3])
 
-        self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longList)
-        self.assertRaises(RuntimeError, utils.calcLmstLast, mjd3, longList)
+        self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
+        self.assertRaises(RuntimeError, utils.calcLmstLast, mjd3, longArr)
+        self.assertRaises(RuntimeError, utils.calcLmstLast, list(mjd2), longArr)
+        self.assertRaises(RuntimeError, utils.calcLmstLast, mjd2, list(longArr))
+        self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
+        ans = utils.calcLmstLast(mjd2, longFloat)
         ans = utils.calcLmstLast(mjdFloat, longFloat)
-        ans = utils.calcLmstLast(mjd2, longList)
+        ans = utils.calcLmstLast(mjd2, longArr)
 
 
     def testEquationOfEquinoxes(self):

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -60,14 +60,6 @@ class testCoordinateTransformations(unittest.TestCase):
 
         longFloat = 1.2
         longArr = numpy.array([1.2, 1.4])
-        latFloat = 0.5
-        latArr = numpy.array([0.5, 0.6])
-
-        raFloat = 1.1
-        raArr = numpy.array([0.2, 0.3])
-
-        decFloat = 1.1
-        decArr = numpy.array([0.2, 0.3])
 
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjd3, longArr)

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -1,5 +1,5 @@
 import os
-import numpy
+import numpy as np
 import unittest
 import palpy as palpy
 import lsst.utils.tests as utilsTests
@@ -20,16 +20,16 @@ def controlEquationOfEquinoxes(mjd):
     D = JD - 2451545.0
     omegaDegrees = 125.04 - 0.052954*D
     Ldegrees = 280.47 + 0.98565*D
-    deltaPsiHours = -0.000319*numpy.sin(numpy.radians(omegaDegrees)) \
-                    - 0.000024 * numpy.sin(2.0*numpy.radians(Ldegrees))
+    deltaPsiHours = -0.000319*np.sin(np.radians(omegaDegrees)) \
+                    - 0.000024 * np.sin(2.0*np.radians(Ldegrees))
     epsilonDegrees = 23.4393 - 0.0000004*D
-    return (deltaPsiHours/24.0)*2.0*numpy.pi*numpy.cos(numpy.radians(epsilonDegrees))
+    return (deltaPsiHours/24.0)*2.0*np.pi*np.cos(np.radians(epsilonDegrees))
 
 def controlCalcGmstGast(mjd):
     #From http://aa.usno.navy.mil/faq/docs/GAST.php Nov. 9 2013
     mjdConv = 2400000.5
     jd2000 = 2451545.0
-    mjd_o = numpy.floor(mjd)
+    mjd_o = np.floor(mjd)
     jd = mjd + mjdConv
     jd_o = mjd_o + mjdConv
     h = 24.*(jd-jd_o)
@@ -37,7 +37,7 @@ def controlCalcGmstGast(mjd):
     d_o = jd_o - jd2000
     t = d/36525.
     gmst = 6.697374558 + 0.06570982441908*d_o + 1.00273790935*h + 0.000026*t**2
-    gast = gmst + 24.0*utils.equationOfEquinoxes(mjd)/(2.0*numpy.pi)
+    gast = gmst + 24.0*utils.equationOfEquinoxes(mjd)/(2.0*np.pi)
     gmst %= 24.
     gast %= 24.
     return gmst, gast
@@ -45,9 +45,9 @@ def controlCalcGmstGast(mjd):
 class testCoordinateTransformations(unittest.TestCase):
 
     def setUp(self):
-        numpy.random.seed(32)
+        np.random.seed(32)
         ntests = 100
-        self.mjd = 57087.0 - 1000.0*(numpy.random.sample(ntests)-0.5)
+        self.mjd = 57087.0 - 1000.0*(np.random.sample(ntests)-0.5)
         self.tolerance = 1.0e-5
 
     def testExceptions(self):
@@ -55,11 +55,11 @@ class testCoordinateTransformations(unittest.TestCase):
         Test to make sure that methods complain when incorrect data types are passed.
         """
         mjdFloat = 52000.0
-        mjd2 = numpy.array([52000.0, 53000.0])
-        mjd3 = numpy.array([53000.0, 53000.0, 54000.0])
+        mjd2 = np.array([52000.0, 53000.0])
+        mjd3 = np.array([53000.0, 53000.0, 54000.0])
 
         longFloat = 1.2
-        longArr = numpy.array([1.2, 1.4])
+        longArr = np.array([1.2, 1.4])
 
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjdFloat, longArr)
         self.assertRaises(RuntimeError, utils.calcLmstLast, mjd3, longArr)
@@ -79,13 +79,13 @@ class testCoordinateTransformations(unittest.TestCase):
         #test vectorized version
         control = controlEquationOfEquinoxes(self.mjd)
         test = utils.equationOfEquinoxes(self.mjd)
-        self.assertTrue(numpy.abs(test-control).max() < self.tolerance)
+        self.assertTrue(np.abs(test-control).max() < self.tolerance)
 
         #test non-vectorized version
         for mm in self.mjd:
             control = controlEquationOfEquinoxes(mm)
             test = utils.equationOfEquinoxes(mm)
-            self.assertTrue(numpy.abs(test-control) < self.tolerance)
+            self.assertTrue(np.abs(test-control) < self.tolerance)
 
     def testGmstGast(self):
         """
@@ -94,15 +94,15 @@ class testCoordinateTransformations(unittest.TestCase):
 
         controlGmst, controlGast = controlCalcGmstGast(self.mjd)
         testGmst, testGast = utils.calcGmstGast(self.mjd)
-        self.assertTrue(numpy.abs(testGmst - controlGmst).max() < self.tolerance)
-        self.assertTrue(numpy.abs(testGast - controlGast).max() < self.tolerance)
+        self.assertTrue(np.abs(testGmst - controlGmst).max() < self.tolerance)
+        self.assertTrue(np.abs(testGast - controlGast).max() < self.tolerance)
 
         #test non-vectorized version
         for mm in self.mjd:
             controlGmst, controlGast = controlCalcGmstGast(mm)
             testGmst, testGast = utils.calcGmstGast(mm)
-            self.assertTrue(numpy.abs(testGmst - controlGmst) < self.tolerance)
-            self.assertTrue(numpy.abs(testGast - controlGast) < self.tolerance)
+            self.assertTrue(np.abs(testGmst - controlGmst) < self.tolerance)
+            self.assertTrue(np.abs(testGast - controlGast) < self.tolerance)
 
     def testLmstLast(self):
         """
@@ -114,7 +114,7 @@ class testCoordinateTransformations(unittest.TestCase):
 
         # test passing a float for longitude and a numpy array for mjd
         for longitude in ll:
-            hours = numpy.degrees(longitude)/15.0
+            hours = np.degrees(longitude)/15.0
             if hours > 24.0:
                 hours -= 24.0
             controlLmst = gmst + hours
@@ -122,16 +122,16 @@ class testCoordinateTransformations(unittest.TestCase):
             controlLmst %= 24.0
             controlLast %= 24.0
             testLmst, testLast = utils.calcLmstLast(self.mjd, longitude)
-            self.assertTrue(numpy.abs(testLmst - controlLmst).max() < self.tolerance)
-            self.assertTrue(numpy.abs(testLast - controlLast).max() < self.tolerance)
-            self.assertIsInstance(testLmst, numpy.ndarray)
-            self.assertIsInstance(testLast, numpy.ndarray)
+            self.assertTrue(np.abs(testLmst - controlLmst).max() < self.tolerance)
+            self.assertTrue(np.abs(testLast - controlLast).max() < self.tolerance)
+            self.assertIsInstance(testLmst, np.ndarray)
+            self.assertIsInstance(testLast, np.ndarray)
 
         # test passing two floats
         for longitude in ll:
             for mm in self.mjd:
                 gmst, gast = utils.calcGmstGast(mm)
-                hours = numpy.degrees(longitude)/15.0
+                hours = np.degrees(longitude)/15.0
                 if hours > 24.0:
                     hours -= 24.0
                 controlLmst = gmst + hours
@@ -139,16 +139,16 @@ class testCoordinateTransformations(unittest.TestCase):
                 controlLmst %= 24.0
                 controlLast %= 24.0
                 testLmst, testLast = utils.calcLmstLast(mm, longitude)
-                self.assertTrue(numpy.abs(testLmst - controlLmst) < self.tolerance)
-                self.assertTrue(numpy.abs(testLast - controlLast) < self.tolerance)
-                self.assertIsInstance(testLmst, numpy.float)
-                self.assertIsInstance(testLast, numpy.float)
+                self.assertTrue(np.abs(testLmst - controlLmst) < self.tolerance)
+                self.assertTrue(np.abs(testLast - controlLast) < self.tolerance)
+                self.assertIsInstance(testLmst, np.float)
+                self.assertIsInstance(testLast, np.float)
 
         # test passing two numpy arrays
-        ll = numpy.random.random_sample(len(self.mjd))*2.0*numpy.pi
+        ll = np.random.random_sample(len(self.mjd))*2.0*np.pi
         testLmst, testLast = utils.calcLmstLast(self.mjd, ll)
-        self.assertIsInstance(testLmst, numpy.ndarray)
-        self.assertIsInstance(testLast, numpy.ndarray)
+        self.assertIsInstance(testLmst, np.ndarray)
+        self.assertIsInstance(testLast, np.ndarray)
         for ix, (longitude, mm) in enumerate(zip(ll, self.mjd)):
             controlLmst, controlLast = utils.calcLmstLast(mm, longitude)
             self.assertAlmostEqual(controlLmst, testLmst[ix], 10)
@@ -157,8 +157,8 @@ class testCoordinateTransformations(unittest.TestCase):
 
     def test_galacticFromEquatorial(self):
 
-        ra=numpy.zeros((3),dtype=float)
-        dec=numpy.zeros((3),dtype=float)
+        ra=np.zeros((3),dtype=float)
+        dec=np.zeros((3),dtype=float)
 
         ra[0]=2.549091039839124218e+00
         dec[0]=5.198752733024248895e-01
@@ -178,8 +178,8 @@ class testCoordinateTransformations(unittest.TestCase):
 
     def test_equatorialFromGalactic(self):
 
-        lon=numpy.zeros((3),dtype=float)
-        lat=numpy.zeros((3),dtype=float)
+        lon=np.zeros((3),dtype=float)
+        lat=np.zeros((3),dtype=float)
 
         lon[0]=3.452036693523627964e+00
         lat[0]=8.559512505657201897e-01
@@ -203,10 +203,10 @@ class testCoordinateTransformations(unittest.TestCase):
         arg2=5.96902604182
         output=utils.cartesianFromSpherical(arg1,arg2)
 
-        vv=numpy.zeros((3),dtype=float)
-        vv[0]=numpy.cos(arg2)*numpy.cos(arg1)
-        vv[1]=numpy.cos(arg2)*numpy.sin(arg1)
-        vv[2]=numpy.sin(arg2)
+        vv=np.zeros((3),dtype=float)
+        vv[0]=np.cos(arg2)*np.cos(arg1)
+        vv[1]=np.cos(arg2)*np.sin(arg1)
+        vv[2]=np.sin(arg2)
 
         self.assertAlmostEqual(output[0],vv[0],7)
         self.assertAlmostEqual(output[1],vv[1],7)
@@ -219,57 +219,57 @@ class testCoordinateTransformations(unittest.TestCase):
 
         Each column of xyz is a vector
         """
-        numpy.random.seed(42)
+        np.random.seed(42)
         nsamples = 10
-        radius = numpy.random.random_sample(nsamples)*10.0
-        theta = numpy.random.random_sample(nsamples)*numpy.pi-0.5*numpy.pi
-        phi = numpy.random.random_sample(nsamples)*2.0*numpy.pi
+        radius = np.random.random_sample(nsamples)*10.0
+        theta = np.random.random_sample(nsamples)*np.pi-0.5*np.pi
+        phi = np.random.random_sample(nsamples)*2.0*np.pi
 
         points = []
         for ix in range(nsamples):
-            vv = [radius[ix]*numpy.cos(theta[ix])*numpy.cos(phi[ix]),
-                  radius[ix]*numpy.cos(theta[ix])*numpy.sin(phi[ix]),
-                  radius[ix]*numpy.sin(theta[ix])]
+            vv = [radius[ix]*np.cos(theta[ix])*np.cos(phi[ix]),
+                  radius[ix]*np.cos(theta[ix])*np.sin(phi[ix]),
+                  radius[ix]*np.sin(theta[ix])]
 
             points.append(vv)
 
-        points = numpy.array(points)
+        points = np.array(points)
         lon, lat = utils.sphericalFromCartesian(points)
         for ix in range(nsamples):
-            self.assertAlmostEqual(numpy.cos(lon[ix]), numpy.cos(phi[ix]), 5)
-            self.assertAlmostEqual(numpy.sin(lon[ix]), numpy.sin(phi[ix]), 5)
-            self.assertAlmostEqual(numpy.cos(lat[ix]), numpy.cos(theta[ix]), 5)
-            self.assertAlmostEqual(numpy.sin(lat[ix]), numpy.sin(theta[ix]), 5)
+            self.assertAlmostEqual(np.cos(lon[ix]), np.cos(phi[ix]), 5)
+            self.assertAlmostEqual(np.sin(lon[ix]), np.sin(phi[ix]), 5)
+            self.assertAlmostEqual(np.cos(lat[ix]), np.cos(theta[ix]), 5)
+            self.assertAlmostEqual(np.sin(lat[ix]), np.sin(theta[ix]), 5)
 
         for pp, th, ph in zip(points, theta, phi):
             lon, lat = utils.sphericalFromCartesian(pp)
-            self.assertAlmostEqual(numpy.cos(lon), numpy.cos(ph), 5)
-            self.assertAlmostEqual(numpy.sin(lon), numpy.sin(ph), 5)
-            self.assertAlmostEqual(numpy.cos(lat), numpy.cos(th), 5)
-            self.assertAlmostEqual(numpy.sin(lat), numpy.sin(th), 5)
+            self.assertAlmostEqual(np.cos(lon), np.cos(ph), 5)
+            self.assertAlmostEqual(np.sin(lon), np.sin(ph), 5)
+            self.assertAlmostEqual(np.cos(lat), np.cos(th), 5)
+            self.assertAlmostEqual(np.sin(lat), np.sin(th), 5)
 
 
     def testCartesianFromSpherical(self):
-        numpy.random.seed(42)
+        np.random.seed(42)
         nsamples = 10
-        theta = numpy.random.random_sample(nsamples)*numpy.pi-0.5*numpy.pi
-        phi = numpy.random.random_sample(nsamples)*2.0*numpy.pi
+        theta = np.random.random_sample(nsamples)*np.pi-0.5*np.pi
+        phi = np.random.random_sample(nsamples)*2.0*np.pi
 
         points = []
         for ix in range(nsamples):
-            vv = [numpy.cos(theta[ix])*numpy.cos(phi[ix]),
-                  numpy.cos(theta[ix])*numpy.sin(phi[ix]),
-                  numpy.sin(theta[ix])]
+            vv = [np.cos(theta[ix])*np.cos(phi[ix]),
+                  np.cos(theta[ix])*np.sin(phi[ix]),
+                  np.sin(theta[ix])]
 
             points.append(vv)
 
 
-        points = numpy.array(points)
+        points = np.array(points)
         lon, lat = utils.sphericalFromCartesian(points)
-        outPoints = utils.cartesianFromSpherical(numpy.array(lon), numpy.array(lat))
+        outPoints = utils.cartesianFromSpherical(np.array(lon), np.array(lat))
 
         for pp, oo in zip(points, outPoints):
-            numpy.testing.assert_array_almost_equal(pp, oo, decimal=6)
+            np.testing.assert_array_almost_equal(pp, oo, decimal=6)
 
     def testHaversine(self):
         arg1 = 7.853981633974482790e-01
@@ -284,9 +284,9 @@ class testCoordinateTransformations(unittest.TestCase):
 
 
     def testRotationMatrixFromVectors(self):
-        v1=numpy.zeros((3),dtype=float)
-        v2=numpy.zeros((3),dtype=float)
-        v3=numpy.zeros((3),dtype=float)
+        v1=np.zeros((3),dtype=float)
+        v2=np.zeros((3),dtype=float)
+        v3=np.zeros((3),dtype=float)
 
         v1[0]=-3.044619987218469825e-01
         v2[0]=5.982190522311925385e-01
@@ -304,7 +304,7 @@ class testCoordinateTransformations(unittest.TestCase):
         for i in range(3):
             self.assertAlmostEqual(v3[i],v2[i],7)
 
-        v1 = numpy.array([1.0, 1.0, 1.0])
+        v1 = np.array([1.0, 1.0, 1.0])
         self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v1, v2)
         self.assertRaises(RuntimeError, utils.rotationMatrixFromVectors, v2, v1)
 

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -202,14 +202,27 @@ class testCoordinateTransformations(unittest.TestCase):
         lon[2]=2.829585540991265358e+00
         lat[2]=-6.510790587552289788e-01
 
-        output=utils._equatorialFromGalactic(lon,lat)
+        ra, dec = utils._equatorialFromGalactic(lon,lat)
 
-        self.assertAlmostEqual(output[0][0],2.549091039839124218e+00,6)
-        self.assertAlmostEqual(output[1][0],5.198752733024248895e-01,6)
-        self.assertAlmostEqual(output[0][1],8.693375673649429425e-01,6)
-        self.assertAlmostEqual(output[1][1],1.038086165642298164e+00,6)
-        self.assertAlmostEqual(output[0][2],7.740864769302191473e-01,6)
-        self.assertAlmostEqual(output[1][2],2.758053025017753179e-01,6)
+        self.assertIsInstance(ra, np.ndarray)
+        self.assertIsInstance(dec, np.ndarray)
+
+        self.assertAlmostEqual(ra[0],2.549091039839124218e+00,6)
+        self.assertAlmostEqual(dec[0],5.198752733024248895e-01,6)
+        self.assertAlmostEqual(ra[1],8.693375673649429425e-01,6)
+        self.assertAlmostEqual(dec[1],1.038086165642298164e+00,6)
+        self.assertAlmostEqual(ra[2],7.740864769302191473e-01,6)
+        self.assertAlmostEqual(dec[2],2.758053025017753179e-01,6)
+
+        # test passing in floats as args
+        for ix, (ll, bb) in enumerate(zip(lon, lat)):
+            rr, dd = utils._equatorialFromGalactic(ll, bb)
+            self.assertIsInstance(ll, np.float)
+            self.assertIsInstance(bb, np.float)
+            self.assertIsInstance(rr, np.float)
+            self.assertIsInstance(dd, np.float)
+            self.assertAlmostEqual(rr, ra[ix], 10)
+            self.assertAlmostEqual(dd, dec[ix], 10)
 
 
     def testCartesianFromSpherical(self):

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 
 import os
-import numpy
+import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 from collections import OrderedDict
@@ -171,9 +171,9 @@ class ObservationMetaDataTest(unittest.TestCase):
         testObsMD = ObservationMetaData(site=testSite)
 
         self.assertAlmostEqual(testObsMD.site.longitude, 20.0, 10)
-        self.assertAlmostEqual(testObsMD.site.longitude_rad, numpy.radians(20.0), 10)
+        self.assertAlmostEqual(testObsMD.site.longitude_rad, np.radians(20.0), 10)
         self.assertAlmostEqual(testObsMD.site.latitude, -71.0, 10)
-        self.assertAlmostEqual(testObsMD.site.latitude_rad, numpy.radians(-71.0), 10)
+        self.assertAlmostEqual(testObsMD.site.latitude_rad, np.radians(-71.0), 10)
         self.assertAlmostEqual(testObsMD.site.height, 4.0, 10)
         self.assertAlmostEqual(testObsMD.site.temperature, 100.0, 10)
         self.assertAlmostEqual(testObsMD.site.temperature_kelvin, 373.15, 10)
@@ -236,9 +236,9 @@ class ObservationMetaDataTest(unittest.TestCase):
 
 
         testObsMD.phoSimMetaData = phosimMD
-        self.assertAlmostEqual(testObsMD.pointingRA, numpy.degrees(-2.0), 10)
-        self.assertAlmostEqual(testObsMD.pointingDec, numpy.degrees(0.9), 10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos, numpy.degrees(1.1))
+        self.assertAlmostEqual(testObsMD.pointingRA, np.degrees(-2.0), 10)
+        self.assertAlmostEqual(testObsMD.pointingDec, np.degrees(0.9), 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, np.degrees(1.1))
         self.assertAlmostEqual(testObsMD.mjd.TAI, 4000.0, 10)
         self.assertAlmostEqual(testObsMD.bandpass, 'g')
 
@@ -259,9 +259,9 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.mjd.TAI,4000.0,10)
 
         #recall that pointingRA/Dec are stored as radians in phoSim metadata
-        self.assertAlmostEqual(testObsMD.pointingRA,numpy.degrees(-2.0),10)
-        self.assertAlmostEqual(testObsMD.pointingDec,numpy.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,numpy.degrees(1.1),10)
+        self.assertAlmostEqual(testObsMD.pointingRA,np.degrees(-2.0),10)
+        self.assertAlmostEqual(testObsMD.pointingDec,np.degrees(0.9),10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,np.degrees(1.1),10)
         self.assertEqual(testObsMD.bandpass,'g')
 
         testObsMD = ObservationMetaData()
@@ -270,9 +270,9 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.mjd.TAI,4000.0,10)
 
         #recall that pointingRA/Dec are stored as radians in phoSim metadata
-        self.assertAlmostEqual(testObsMD.pointingRA,numpy.degrees(-2.0),10)
-        self.assertAlmostEqual(testObsMD.pointingDec,numpy.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,numpy.degrees(1.1),10)
+        self.assertAlmostEqual(testObsMD.pointingRA,np.degrees(-2.0),10)
+        self.assertAlmostEqual(testObsMD.pointingDec,np.degrees(0.9),10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos,np.degrees(1.1),10)
         self.assertEqual(testObsMD.bandpass,'g')
 
 
@@ -294,15 +294,15 @@ class ObservationMetaDataTest(unittest.TestCase):
         """
         boxBounds = [0.1, 0.3]
         circObs = ObservationMetaData(boundType='circle', pointingRA=0.0, pointingDec=0.0, boundLength=1.0, mjd=53580.0)
-        boundControl = CircleBounds(0.0, 0.0, numpy.radians(1.0))
+        boundControl = CircleBounds(0.0, 0.0, np.radians(1.0))
         self.assertEqual(circObs.bounds, boundControl)
 
         squareObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0, boundLength=1.0, mjd=53580.0)
-        boundControl = BoxBounds(0.0, 0.0, numpy.radians(1.0))
+        boundControl = BoxBounds(0.0, 0.0, np.radians(1.0))
         self.assertEqual(squareObs.bounds, boundControl)
 
         boxObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0, boundLength=boxBounds, mjd=53580.0)
-        boundControl = BoxBounds(0.0, 0.0, numpy.radians([0.1, 0.3]))
+        boundControl = BoxBounds(0.0, 0.0, np.radians([0.1, 0.3]))
         self.assertEqual(boxObs.bounds, boundControl)
 
     def testBounds(self):
@@ -317,7 +317,7 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         boxRA = 15.0
         boxDec = 0.0
-        boxLength = numpy.array([5.0,10.0])
+        boxLength = np.array([5.0,10.0])
 
         testObsMD = ObservationMetaData(boundType='circle',
                      pointingRA = circRA, pointingDec=circDec, boundLength = radius, mjd=53580.0)

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -1,12 +1,12 @@
 from __future__ import with_statement
 
-import os
 import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 from collections import OrderedDict
 from lsst.sims.utils import ObservationMetaData, ModifiedJulianDate
 from lsst.sims.utils import Site, BoxBounds, CircleBounds
+
 
 class ObservationMetaDataTest(unittest.TestCase):
     """
@@ -22,34 +22,33 @@ class ObservationMetaDataTest(unittest.TestCase):
         parameters are overwritten in an unintentional way
         """
 
-        metadata = {'pointingRA':[1.5], 'pointingDec':[0.5],
-                    'Opsim_expmjd':[52000.0],
-                    'Opsim_rotskypos':[1.3],
-                    'Opsim_filter':[2],
-                    'Opsim_rawseeing':[0.7]}
+        metadata = {'pointingRA': [1.5], 'pointingDec': [0.5],
+                    'Opsim_expmjd': [52000.0],
+                    'Opsim_rotskypos': [1.3],
+                    'Opsim_filter': [2],
+                    'Opsim_rawseeing': [0.7]}
 
         obs_metadata = ObservationMetaData(phoSimMetaData=metadata,
                                            boundType='circle',
                                            boundLength=0.1)
 
         with self.assertRaises(RuntimeError):
-            obs_metadata.pointingRA=1.2
+            obs_metadata.pointingRA = 1.2
 
         with self.assertRaises(RuntimeError):
-            obs_metadata.pointingDec=1.2
+            obs_metadata.pointingDec = 1.2
 
         with self.assertRaises(RuntimeError):
-            obs_metadata.rotSkyPos=1.5
+            obs_metadata.rotSkyPos = 1.5
 
         with self.assertRaises(RuntimeError):
-            obs_metadata.seeing=0.5
+            obs_metadata.seeing = 0.5
 
         with self.assertRaises(RuntimeError):
             obs_metadata.setBandpassM5andSeeing()
 
         obs_metadata = ObservationMetaData(pointingRA=1.5,
                                            pointingDec=1.5)
-
 
     def testM5(self):
         """
@@ -66,11 +65,10 @@ class ObservationMetaDataTest(unittest.TestCase):
         obsMD = ObservationMetaData(bandpassName='g', m5=12.0)
         self.assertAlmostEqual(obsMD.m5['g'], 12.0, 10)
 
-        obsMD = ObservationMetaData(bandpassName=['u','g','r'], m5=[10,11,12])
+        obsMD = ObservationMetaData(bandpassName=['u', 'g', 'r'], m5=[10, 11, 12])
         self.assertEqual(obsMD.m5['u'], 10)
         self.assertEqual(obsMD.m5['g'], 11)
         self.assertEqual(obsMD.m5['r'], 12)
-
 
     def testSeeing(self):
         """
@@ -87,23 +85,22 @@ class ObservationMetaDataTest(unittest.TestCase):
         obsMD = ObservationMetaData(bandpassName='g', seeing=0.7)
         self.assertAlmostEqual(obsMD.seeing['g'], 0.7, 10)
 
-        obsMD = ObservationMetaData(bandpassName=['u','g','r'], seeing=[0.7,0.6,0.5])
+        obsMD = ObservationMetaData(bandpassName=['u', 'g', 'r'], seeing=[0.7, 0.6, 0.5])
         self.assertEqual(obsMD.seeing['u'], 0.7)
         self.assertEqual(obsMD.seeing['g'], 0.6)
         self.assertEqual(obsMD.seeing['r'], 0.5)
-
 
     def testM5andSeeingAssignment(self):
         """
         Test assignment of m5 and seeing seeing and bandpass in ObservationMetaData
         """
-        obsMD = ObservationMetaData(bandpassName=['u','g'], m5=[15.0, 16.0], seeing=[0.7, 0.6])
+        obsMD = ObservationMetaData(bandpassName=['u', 'g'], m5=[15.0, 16.0], seeing=[0.7, 0.6])
         self.assertAlmostEqual(obsMD.m5['u'], 15.0, 10)
         self.assertAlmostEqual(obsMD.m5['g'], 16.0, 10)
         self.assertAlmostEqual(obsMD.seeing['u'], 0.7, 10)
         self.assertAlmostEqual(obsMD.seeing['g'], 0.6, 10)
 
-        obsMD.setBandpassM5andSeeing(bandpassName=['i','z'], m5=[25.0, 22.0], seeing=[0.5, 0.4])
+        obsMD.setBandpassM5andSeeing(bandpassName=['i', 'z'], m5=[25.0, 22.0], seeing=[0.5, 0.4])
         self.assertAlmostEqual(obsMD.m5['i'], 25.0, 10)
         self.assertAlmostEqual(obsMD.m5['z'], 22.0, 10)
         self.assertAlmostEqual(obsMD.seeing['i'], 0.5, 10)
@@ -131,12 +128,11 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(obsMD.seeing['w'], 0.9, 10)
         self.assertAlmostEqual(obsMD.seeing['x'], 1.1, 10)
 
-        phoSimMD = {'Opsim_filter':[4]}
+        phoSimMD = {'Opsim_filter': [4]}
         obsMD.phoSimMetaData = phoSimMD
         self.assertEqual(obsMD.bandpass, 4)
         self.assertTrue(obsMD.m5 is None)
         self.assertTrue(obsMD.seeing is None)
-
 
     def testDefault(self):
         """
@@ -210,7 +206,7 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.boundLength[1], 3.0, 10)
         self.assertAlmostEqual(testObsMD.mjd.TAI, mjd, 10)
 
-        #test reassignment
+        # test reassignment
 
         testObsMD.pointingRA = RA+1.0
         testObsMD.pointingDec = Dec+1.0
@@ -225,15 +221,14 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.rotSkyPos, rotSkyPos+1.0, 10)
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness+1.0, 10)
         self.assertEqual(testObsMD.boundType, 'circle')
-        self.assertAlmostEqual(testObsMD.boundLength,2.2, 10)
+        self.assertAlmostEqual(testObsMD.boundLength, 2.2, 10)
         self.assertAlmostEqual(testObsMD.mjd.TAI, mjd+10.0, 10)
 
-        phosimMD = OrderedDict([('pointingRA', (-2.0,float)),
-                                ('pointingDec', (0.9,float)),
-                                ('Opsim_rotskypos', (1.1,float)),
-                                ('Opsim_expmjd',(4000.0,float)),
-                                ('Opsim_filter',('g',str))])
-
+        phosimMD = OrderedDict([('pointingRA', (-2.0, float)),
+                                ('pointingDec', (0.9, float)),
+                                ('Opsim_rotskypos', (1.1, float)),
+                                ('Opsim_expmjd', (4000.0, float)),
+                                ('Opsim_filter', ('g', str))])
 
         testObsMD.phoSimMetaData = phosimMD
         self.assertAlmostEqual(testObsMD.pointingRA, np.degrees(-2.0), 10)
@@ -243,38 +238,37 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertAlmostEqual(testObsMD.bandpass, 'g')
 
         testObsMD = ObservationMetaData(mjd=mjd, pointingRA=RA,
-            pointingDec=Dec, rotSkyPos=rotSkyPos, bandpassName='z',
-            skyBrightness=skyBrightness)
+                                        pointingDec=Dec, rotSkyPos=rotSkyPos, bandpassName='z',
+                                        skyBrightness=skyBrightness)
 
-        self.assertAlmostEqual(testObsMD.mjd.TAI,5120.0,10)
-        self.assertAlmostEqual(testObsMD.pointingRA,1.5,10)
-        self.assertAlmostEqual(testObsMD.pointingDec,-1.1,10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,-10.0,10)
-        self.assertEqual(testObsMD.bandpass,'z')
+        self.assertAlmostEqual(testObsMD.mjd.TAI, 5120.0, 10)
+        self.assertAlmostEqual(testObsMD.pointingRA, 1.5, 10)
+        self.assertAlmostEqual(testObsMD.pointingDec, -1.1, 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, -10.0, 10)
+        self.assertEqual(testObsMD.bandpass, 'z')
         self.assertAlmostEqual(testObsMD.skyBrightness, skyBrightness, 10)
 
         testObsMD = ObservationMetaData()
         testObsMD.phoSimMetaData = phosimMD
 
-        self.assertAlmostEqual(testObsMD.mjd.TAI,4000.0,10)
+        self.assertAlmostEqual(testObsMD.mjd.TAI, 4000.0, 10)
 
-        #recall that pointingRA/Dec are stored as radians in phoSim metadata
-        self.assertAlmostEqual(testObsMD.pointingRA,np.degrees(-2.0),10)
-        self.assertAlmostEqual(testObsMD.pointingDec,np.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,np.degrees(1.1),10)
-        self.assertEqual(testObsMD.bandpass,'g')
+        # recall that pointingRA/Dec are stored as radians in phoSim metadata
+        self.assertAlmostEqual(testObsMD.pointingRA, np.degrees(-2.0), 10)
+        self.assertAlmostEqual(testObsMD.pointingDec, np.degrees(0.9), 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, np.degrees(1.1), 10)
+        self.assertEqual(testObsMD.bandpass, 'g')
 
         testObsMD = ObservationMetaData()
         testObsMD.phoSimMetaData = phosimMD
 
-        self.assertAlmostEqual(testObsMD.mjd.TAI,4000.0,10)
+        self.assertAlmostEqual(testObsMD.mjd.TAI, 4000.0, 10)
 
-        #recall that pointingRA/Dec are stored as radians in phoSim metadata
-        self.assertAlmostEqual(testObsMD.pointingRA,np.degrees(-2.0),10)
-        self.assertAlmostEqual(testObsMD.pointingDec,np.degrees(0.9),10)
-        self.assertAlmostEqual(testObsMD.rotSkyPos,np.degrees(1.1),10)
-        self.assertEqual(testObsMD.bandpass,'g')
-
+        # recall that pointingRA/Dec are stored as radians in phoSim metadata
+        self.assertAlmostEqual(testObsMD.pointingRA, np.degrees(-2.0), 10)
+        self.assertAlmostEqual(testObsMD.pointingDec, np.degrees(0.9), 10)
+        self.assertAlmostEqual(testObsMD.rotSkyPos, np.degrees(1.1), 10)
+        self.assertEqual(testObsMD.bandpass, 'g')
 
         # test assigning ModifiedJulianDate
         obs = ObservationMetaData()
@@ -287,21 +281,23 @@ class ObservationMetaDataTest(unittest.TestCase):
         self.assertEqual(obs.mjd, mjd2)
         self.assertNotEqual(obs.mjd, mjd)
 
-
     def testBoundBuilding(self):
         """
         Make sure ObservationMetaData can build bounds
         """
         boxBounds = [0.1, 0.3]
-        circObs = ObservationMetaData(boundType='circle', pointingRA=0.0, pointingDec=0.0, boundLength=1.0, mjd=53580.0)
+        circObs = ObservationMetaData(boundType='circle', pointingRA=0.0, pointingDec=0.0,
+                                      boundLength=1.0, mjd=53580.0)
         boundControl = CircleBounds(0.0, 0.0, np.radians(1.0))
         self.assertEqual(circObs.bounds, boundControl)
 
-        squareObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0, boundLength=1.0, mjd=53580.0)
+        squareObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0,
+                                        boundLength=1.0, mjd=53580.0)
         boundControl = BoxBounds(0.0, 0.0, np.radians(1.0))
         self.assertEqual(squareObs.bounds, boundControl)
 
-        boxObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0, boundLength=boxBounds, mjd=53580.0)
+        boxObs = ObservationMetaData(boundType = 'box', pointingRA=0.0, pointingDec=0.0,
+                                     boundLength=boxBounds, mjd=53580.0)
         boundControl = BoxBounds(0.0, 0.0, np.radians([0.1, 0.3]))
         self.assertEqual(boxObs.bounds, boundControl)
 
@@ -317,10 +313,11 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         boxRA = 15.0
         boxDec = 0.0
-        boxLength = np.array([5.0,10.0])
+        boxLength = np.array([5.0, 10.0])
 
         testObsMD = ObservationMetaData(boundType='circle',
-                     pointingRA = circRA, pointingDec=circDec, boundLength = radius, mjd=53580.0)
+                                        pointingRA = circRA, pointingDec=circDec,
+                                        boundLength = radius, mjd=53580.0)
         self.assertAlmostEqual(testObsMD.pointingRA, 25.0, 10)
         self.assertAlmostEqual(testObsMD.pointingDec, 50.0, 10)
 
@@ -329,7 +326,6 @@ class ObservationMetaDataTest(unittest.TestCase):
                                         mjd=53580.0)
         self.assertAlmostEqual(testObsMD.pointingRA, 15.0, 10)
         self.assertAlmostEqual(testObsMD.pointingDec, 0.0, 10)
-
 
     def testSummary(self):
         """
@@ -346,6 +342,7 @@ def suite():
     suites += unittest.makeSuite(ObservationMetaDataTest)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit=False):
     """Run the tests"""

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 
@@ -20,11 +20,11 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                            rotSkyPos=25.0,
                                            mjd=52000.0)
 
-        numpy.random.seed(42)
-        ra = numpy.random.random_sample(10)*numpy.radians(1.0) + numpy.radians(obs_metadata.pointingRA)
-        dec = numpy.random.random_sample(10)*numpy.radians(1.0) + numpy.radians(obs_metadata.pointingDec)
-        raShort = numpy.array([1.0])
-        decShort = numpy.array([1.0])
+        np.random.seed(42)
+        ra = np.random.random_sample(10)*np.radians(1.0) + np.radians(obs_metadata.pointingRA)
+        dec = np.random.random_sample(10)*np.radians(1.0) + np.radians(obs_metadata.pointingDec)
+        raShort = np.array([1.0])
+        decShort = np.array([1.0])
 
         #test without epoch
         self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
@@ -112,52 +112,52 @@ class PupilCoordinateUnitTest(unittest.TestCase):
 
         epoch = 2000.0
         mjd = 42350.0
-        numpy.random.seed(42)
-        raList = numpy.random.random_sample(10)*360.0
-        decList = numpy.random.random_sample(10)*180.0 - 90.0
+        np.random.seed(42)
+        raList = np.random.random_sample(10)*360.0
+        decList = np.random.random_sample(10)*180.0 - 90.0
 
 
-        for rotSkyPos in numpy.arange(-90.0, 181.0, 90.0):
+        for rotSkyPos in np.arange(-90.0, 181.0, 90.0):
             for ra, dec in zip(raList, decList):
                 obs = ObservationMetaData(pointingRA=ra,
                                           pointingDec=dec,
                                           mjd=mjd,
                                           rotSkyPos=rotSkyPos)
 
-                ra_obs, dec_obs = _observedFromICRS(numpy.radians([ra]), numpy.radians([dec]),
+                ra_obs, dec_obs = _observedFromICRS(np.radians([ra]), np.radians([dec]),
                                                     obs_metadata=obs, epoch=2000.0,
                                                     includeRefraction=True)
 
                 # test points that are displaced just to the (E, W, N, S) of the pointing
                 # in observed geocentric RA, Dec; verify that the pupil coordinates
                 # change as expected
-                raTest_obs = ra_obs[0] + numpy.array([0.01, -0.01, 0.0, 0.0])
-                decTest_obs = dec_obs[0] + numpy.array([0.0, 0.0, 0.01, -0.01])
+                raTest_obs = ra_obs[0] + np.array([0.01, -0.01, 0.0, 0.0])
+                decTest_obs = dec_obs[0] + np.array([0.0, 0.0, 0.01, -0.01])
                 raTest, decTest = _icrsFromObserved(raTest_obs, decTest_obs, obs_metadata=obs,
                                                     epoch=2000.0, includeRefraction=True)
 
                 x, y = _pupilCoordsFromRaDec(raTest, decTest, obs_metadata=obs, epoch=epoch)
 
                 lon, lat = _nativeLonLatFromRaDec(raTest, decTest, obs)
-                rr = numpy.abs(numpy.cos(lat)/numpy.sin(lat))
+                rr = np.abs(np.cos(lat)/np.sin(lat))
 
-                if numpy.abs(rotSkyPos)<0.01:
-                    control_x = numpy.array([-1.0*rr[0], 1.0*rr[1], 0.0, 0.0])
-                    control_y = numpy.array([0.0, 0.0, 1.0*rr[2], -1.0*rr[3]])
-                elif numpy.abs(rotSkyPos+90.0)<0.01:
-                    control_x = numpy.array([0.0, 0.0, 1.0*rr[2], -1.0*rr[3]])
-                    control_y = numpy.array([1.0*rr[0], -1.0*rr[1], 0.0, 0.0])
-                elif numpy.abs(rotSkyPos-90.0)<0.01:
-                    control_x = numpy.array([0.0, 0.0, -1.0*rr[2], 1.0*rr[3]])
-                    control_y = numpy.array([-1.0*rr[0], 1.0*rr[1], 0.0, 0.0])
-                elif numpy.abs(rotSkyPos-180.0)<0.01:
-                    control_x = numpy.array([1.0*rr[0], -1.0*rr[1], 0.0, 0.0])
-                    control_y = numpy.array([0.0, 0.0, -1.0*rr[2], 1.0*rr[3]])
+                if np.abs(rotSkyPos)<0.01:
+                    control_x = np.array([-1.0*rr[0], 1.0*rr[1], 0.0, 0.0])
+                    control_y = np.array([0.0, 0.0, 1.0*rr[2], -1.0*rr[3]])
+                elif np.abs(rotSkyPos+90.0)<0.01:
+                    control_x = np.array([0.0, 0.0, 1.0*rr[2], -1.0*rr[3]])
+                    control_y = np.array([1.0*rr[0], -1.0*rr[1], 0.0, 0.0])
+                elif np.abs(rotSkyPos-90.0)<0.01:
+                    control_x = np.array([0.0, 0.0, -1.0*rr[2], 1.0*rr[3]])
+                    control_y = np.array([-1.0*rr[0], 1.0*rr[1], 0.0, 0.0])
+                elif np.abs(rotSkyPos-180.0)<0.01:
+                    control_x = np.array([1.0*rr[0], -1.0*rr[1], 0.0, 0.0])
+                    control_y = np.array([0.0, 0.0, -1.0*rr[2], 1.0*rr[3]])
 
-                dx = numpy.array([xx/cc if numpy.abs(cc)>1.0e-10 else 1.0-xx for xx, cc in zip(x, control_x)])
-                dy = numpy.array([yy/cc if numpy.abs(cc)>1.0e-10 else 1.0-yy for yy, cc in zip(y, control_y)])
-                numpy.testing.assert_array_almost_equal(dx, numpy.ones(4), decimal=4)
-                numpy.testing.assert_array_almost_equal(dy, numpy.ones(4), decimal=4)
+                dx = np.array([xx/cc if np.abs(cc)>1.0e-10 else 1.0-xx for xx, cc in zip(x, control_x)])
+                dy = np.array([yy/cc if np.abs(cc)>1.0e-10 else 1.0-yy for yy, cc in zip(y, control_y)])
+                np.testing.assert_array_almost_equal(dx, np.ones(4), decimal=4)
+                np.testing.assert_array_almost_equal(dy, np.ones(4), decimal=4)
 
 
     def testRaDecFromPupil(self):
@@ -181,14 +181,14 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                   mjd=mjd)
 
         nSamples = 1000
-        numpy.random.seed(42)
-        ra = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(raCenter)
-        dec = (numpy.random.random_sample(nSamples)*0.1-0.2) + numpy.radians(decCenter)
+        np.random.seed(42)
+        ra = (np.random.random_sample(nSamples)*0.1-0.2) + np.radians(raCenter)
+        dec = (np.random.random_sample(nSamples)*0.1-0.2) + np.radians(decCenter)
         xp, yp = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs, epoch=2000.0)
         raTest, decTest = _raDecFromPupilCoords(xp, yp, obs_metadata=obs, epoch=2000.0)
         distance = arcsecFromRadians(haversine(ra, dec, raTest, decTest))
-        dex = numpy.argmax(distance)
-        worstSolarDistance = distanceToSun(numpy.degrees(ra[dex]), numpy.degrees(dec[dex]), mjd.TDB)
+        dex = np.argmax(distance)
+        worstSolarDistance = distanceToSun(np.degrees(ra[dex]), np.degrees(dec[dex]), mjd.TDB)
         msg = "_raDecFromPupilCoords off by %e arcsec at distance to Sun of %e degrees" % \
         (distance.max(), worstSolarDistance)
         self.assertLess(distance.max(), 0.005, msg=msg)
@@ -201,19 +201,19 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         obs = ObservationMetaData(pointingRA=42.0, pointingDec=-28.0,
                                   rotSkyPos=111.0, mjd=42356.0)
         nSamples = 100
-        numpy.random.seed(42)
-        raList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 + 42.0)
-        decList = numpy.radians(numpy.random.random_sample(nSamples)*2.0 -28.0)
+        np.random.seed(42)
+        raList = np.radians(np.random.random_sample(nSamples)*2.0 + 42.0)
+        decList = np.radians(np.random.random_sample(nSamples)*2.0 -28.0)
 
         xControl, yControl = _pupilCoordsFromRaDec(raList, decList,
                                                        obs_metadata=obs,
                                                        epoch=2000.0)
 
-        raList[5] = numpy.NaN
-        decList[5] = numpy.NaN
-        raList[15] = numpy.NaN
-        decList[20] = numpy.NaN
-        raList[30] = numpy.radians(42.0) + numpy.pi
+        raList[5] = np.NaN
+        decList[5] = np.NaN
+        raList[15] = np.NaN
+        decList[20] = np.NaN
+        raList[30] = np.radians(42.0) + np.pi
 
         xTest, yTest = _pupilCoordsFromRaDec(raList, decList,
                                                  obs_metadata=obs,
@@ -224,11 +224,11 @@ class PupilCoordinateUnitTest(unittest.TestCase):
             if ix!=5 and ix!=15 and ix!=20 and ix!=30:
                 self.assertAlmostEqual(xc, xt, 10)
                 self.assertAlmostEqual(yc, yt, 10)
-                self.assertFalse(numpy.isnan(xt))
-                self.assertFalse(numpy.isnan(yt))
+                self.assertFalse(np.isnan(xt))
+                self.assertFalse(np.isnan(yt))
             else:
-                self.assertTrue(numpy.isnan(xt))
-                self.assertTrue(numpy.isnan(yt))
+                self.assertTrue(np.isnan(xt))
+                self.assertTrue(np.isnan(yt))
 
 
 def suite():

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -71,8 +71,20 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, raShort, dec, epoch=2000.0,
                           obs_metadata=dummy)
 
-        #test that it actually runs
-        test = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata, epoch=2000.0)
+        # test that it actually runs (and that passing in either numpy arrays or floats gives
+        # the same results)
+        xx_arr, yy_arr = _pupilCoordsFromRaDec(ra, dec, obs_metadata=obs_metadata)
+        self.assertIsInstance(xx_arr, np.ndarray)
+        self.assertIsInstance(yy_arr, np.ndarray)
+
+        for ix in range(len(ra)):
+            xx_f, yy_f = _pupilCoordsFromRaDec(ra[ix], dec[ix], obs_metadata=obs_metadata)
+            self.assertIsInstance(xx_f, np.float)
+            self.assertIsInstance(yy_f, np.float)
+            self.assertAlmostEqual(xx_arr[ix], xx_f, 12)
+            self.assertAlmostEqual(yy_arr[ix], yy_f, 12)
+            self.assertFalse(np.isnan(xx_f))
+            self.assertFalse(np.isnan(yy_f))
 
 
     def testCardinalDirections(self):

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -26,10 +26,6 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         raShort = np.array([1.0])
         decShort = np.array([1.0])
 
-        #test without epoch
-        self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
-                          obs_metadata=obs_metadata)
-
         #test without obs_metadata
         self.assertRaises(RuntimeError, _pupilCoordsFromRaDec, ra, dec,
                           epoch=2000.0)

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -166,7 +166,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         """
 
         mjd = ModifiedJulianDate(TAI=52000.0)
-        solarRA, solarDec = solarRaDec(mjd.TDB)
+        solarRA, solarDec = solarRaDec(mjd)
 
         # to make sure that we are more than 45 degrees from the Sun as required
         # for _icrsFromObserved to be at all accurate
@@ -188,7 +188,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         raTest, decTest = _raDecFromPupilCoords(xp, yp, obs_metadata=obs, epoch=2000.0)
         distance = arcsecFromRadians(haversine(ra, dec, raTest, decTest))
         dex = np.argmax(distance)
-        worstSolarDistance = distanceToSun(np.degrees(ra[dex]), np.degrees(dec[dex]), mjd.TDB)
+        worstSolarDistance = distanceToSun(np.degrees(ra[dex]), np.degrees(dec[dex]), mjd)
         msg = "_raDecFromPupilCoords off by %e arcsec at distance to Sun of %e degrees" % \
         (distance.max(), worstSolarDistance)
         self.assertLess(distance.max(), 0.005, msg=msg)

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -201,6 +201,14 @@ class PupilCoordinateUnitTest(unittest.TestCase):
         (distance.max(), worstSolarDistance)
         self.assertLess(distance.max(), 0.005, msg=msg)
 
+        # now check that passing in the xp, yp values one at a time still gives the right answer
+        for ix in range(len(ra)):
+            ra_f, dec_f = _raDecFromPupilCoords(xp[ix], yp[ix], obs_metadata=obs, epoch=2000.0)
+            self.assertIsInstance(ra_f, np.float)
+            self.assertIsInstance(dec_f, np.float)
+            dist_f = arcsecFromRadians(haversine(ra_f, dec_f, raTest[ix], decTest[ix]))
+            self.assertLess(dist_f, 1.0e-9)
+
 
     def testNaNs(self):
         """

--- a/tests/testSpatialBounds.py
+++ b/tests/testSpatialBounds.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 
 import os
-import numpy
+import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 from lsst.sims.utils import SpatialBounds, CircleBounds, BoxBounds
@@ -47,37 +47,37 @@ class SpatialBoundsTest(unittest.TestCase):
         myFov1 = SpatialBounds.getSpatialBounds('box',1.0,2.0,1.0)
         self.assertEqual(myFov1.RA,1.0)
         self.assertEqual(myFov1.DEC,2.0)
-        self.assertEqual(myFov1.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov1.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov1.DECmaxDeg,numpy.degrees(3.0))
-        self.assertEqual(myFov1.DECminDeg,numpy.degrees(1.0))
+        self.assertEqual(myFov1.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov1.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov1.DECmaxDeg,np.degrees(3.0))
+        self.assertEqual(myFov1.DECminDeg,np.degrees(1.0))
 
         length = [1.0]
         myFov2 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov2.RA,1.0)
         self.assertEqual(myFov2.DEC,2.0)
-        self.assertEqual(myFov2.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov2.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov2.DECmaxDeg,numpy.degrees(3.0))
-        self.assertEqual(myFov2.DECminDeg,numpy.degrees(1.0))
+        self.assertEqual(myFov2.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov2.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov2.DECmaxDeg,np.degrees(3.0))
+        self.assertEqual(myFov2.DECminDeg,np.degrees(1.0))
 
         length = (1.0)
         myFov3 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov3.RA,1.0)
         self.assertEqual(myFov3.DEC,2.0)
-        self.assertEqual(myFov3.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov3.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov3.DECmaxDeg,numpy.degrees(3.0))
-        self.assertEqual(myFov3.DECminDeg,numpy.degrees(1.0))
+        self.assertEqual(myFov3.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov3.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov3.DECmaxDeg,np.degrees(3.0))
+        self.assertEqual(myFov3.DECminDeg,np.degrees(1.0))
 
-        length = numpy.array([1.0])
+        length = np.array([1.0])
         myFov4 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov4.RA,1.0)
         self.assertEqual(myFov4.DEC,2.0)
-        self.assertEqual(myFov4.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov4.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov4.DECmaxDeg,numpy.degrees(3.0))
-        self.assertEqual(myFov4.DECminDeg,numpy.degrees(1.0))
+        self.assertEqual(myFov4.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov4.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov4.DECmaxDeg,np.degrees(3.0))
+        self.assertEqual(myFov4.DECminDeg,np.degrees(1.0))
 
         self.assertRaises(RuntimeError,SpatialBounds.getSpatialBounds,
                           'utterNonsense',1.0,2.0,length)
@@ -88,28 +88,28 @@ class SpatialBoundsTest(unittest.TestCase):
         myFov2 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov2.RA,1.0)
         self.assertEqual(myFov2.DEC,2.0)
-        self.assertEqual(myFov2.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov2.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov2.DECmaxDeg,numpy.degrees(4.0))
-        self.assertEqual(myFov2.DECminDeg,numpy.degrees(0.0))
+        self.assertEqual(myFov2.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov2.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov2.DECmaxDeg,np.degrees(4.0))
+        self.assertEqual(myFov2.DECminDeg,np.degrees(0.0))
 
         length = (1.0,2.0)
         myFov3 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov3.RA,1.0)
         self.assertEqual(myFov3.DEC,2.0)
-        self.assertEqual(myFov3.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov3.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov3.DECmaxDeg,numpy.degrees(4.0))
-        self.assertEqual(myFov3.DECminDeg,numpy.degrees(0.0))
+        self.assertEqual(myFov3.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov3.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov3.DECmaxDeg,np.degrees(4.0))
+        self.assertEqual(myFov3.DECminDeg,np.degrees(0.0))
 
-        length = numpy.array([1.0,2.0])
+        length = np.array([1.0,2.0])
         myFov4 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
         self.assertEqual(myFov4.RA,1.0)
         self.assertEqual(myFov4.DEC,2.0)
-        self.assertEqual(myFov4.RAmaxDeg,numpy.degrees(2.0))
-        self.assertEqual(myFov4.RAminDeg,numpy.degrees(0.0))
-        self.assertEqual(myFov4.DECmaxDeg,numpy.degrees(4.0))
-        self.assertEqual(myFov4.DECminDeg,numpy.degrees(0.0))
+        self.assertEqual(myFov4.RAmaxDeg,np.degrees(2.0))
+        self.assertEqual(myFov4.RAminDeg,np.degrees(0.0))
+        self.assertEqual(myFov4.DECmaxDeg,np.degrees(4.0))
+        self.assertEqual(myFov4.DECminDeg,np.degrees(0.0))
 
         self.assertRaises(RuntimeError,SpatialBounds.getSpatialBounds,
                           'box',1.0,2.0,'moreUtterNonsense')

--- a/tests/testSpatialBounds.py
+++ b/tests/testSpatialBounds.py
@@ -1,10 +1,10 @@
 from __future__ import with_statement
 
-import os
 import numpy as np
 import unittest
 import lsst.utils.tests as utilsTests
 from lsst.sims.utils import SpatialBounds, CircleBounds, BoxBounds
+
 
 class SpatialBoundsTest(unittest.TestCase):
 
@@ -15,104 +15,105 @@ class SpatialBoundsTest(unittest.TestCase):
         """
 
         with self.assertRaises(RuntimeError):
-            circ = CircleBounds(1.0, 2.0, [3.0,4.0])
+            CircleBounds(1.0, 2.0, [3.0, 4.0])
 
         with self.assertRaises(RuntimeError):
-            circ = CircleBounds('a',2.0,3.0)
+            CircleBounds('a', 2.0, 3.0)
 
         with self.assertRaises(RuntimeError):
-            circ = CircleBounds(1.0, 'b', 4.0)
+            CircleBounds(1.0, 'b', 4.0)
 
-        circ = CircleBounds(1.0,2.0,3)
-
-        with self.assertRaises(RuntimeError):
-            box = BoxBounds(1.0, 2.0, 'abcde')
+        CircleBounds(1.0, 2.0, 3)
 
         with self.assertRaises(RuntimeError):
-            box = BoxBounds('a', 2, 3.0)
+            BoxBounds(1.0, 2.0, 'abcde')
 
         with self.assertRaises(RuntimeError):
-            box = BoxBounds(1.0, 'b', 4.0)
+            BoxBounds('a', 2, 3.0)
 
-        box = BoxBounds(1,2,3)
-        box = BoxBounds(1,2,[3,5])
+        with self.assertRaises(RuntimeError):
+            BoxBounds(1.0, 'b', 4.0)
+
+        BoxBounds(1, 2, 3)
+        BoxBounds(1, 2, [3, 5])
 
     def testCircle(self):
-        myFov = SpatialBounds.getSpatialBounds('circle',1.0,2.0,1.0)
-        self.assertEqual(myFov.RA,1.0)
-        self.assertEqual(myFov.DEC,2.0)
-        self.assertEqual(myFov.radius,1.0)
+        myFov = SpatialBounds.getSpatialBounds('circle', 1.0, 2.0, 1.0)
+        self.assertEqual(myFov.RA, 1.0)
+        self.assertEqual(myFov.DEC, 2.0)
+        self.assertEqual(myFov.radius, 1.0)
 
     def testSquare(self):
-        myFov1 = SpatialBounds.getSpatialBounds('box',1.0,2.0,1.0)
-        self.assertEqual(myFov1.RA,1.0)
-        self.assertEqual(myFov1.DEC,2.0)
-        self.assertEqual(myFov1.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov1.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov1.DECmaxDeg,np.degrees(3.0))
-        self.assertEqual(myFov1.DECminDeg,np.degrees(1.0))
+        myFov1 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, 1.0)
+        self.assertEqual(myFov1.RA, 1.0)
+        self.assertEqual(myFov1.DEC, 2.0)
+        self.assertEqual(myFov1.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov1.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov1.DECmaxDeg, np.degrees(3.0))
+        self.assertEqual(myFov1.DECminDeg, np.degrees(1.0))
 
         length = [1.0]
-        myFov2 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov2.RA,1.0)
-        self.assertEqual(myFov2.DEC,2.0)
-        self.assertEqual(myFov2.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov2.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov2.DECmaxDeg,np.degrees(3.0))
-        self.assertEqual(myFov2.DECminDeg,np.degrees(1.0))
+        myFov2 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov2.RA, 1.0)
+        self.assertEqual(myFov2.DEC, 2.0)
+        self.assertEqual(myFov2.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov2.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov2.DECmaxDeg, np.degrees(3.0))
+        self.assertEqual(myFov2.DECminDeg, np.degrees(1.0))
 
         length = (1.0)
-        myFov3 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov3.RA,1.0)
-        self.assertEqual(myFov3.DEC,2.0)
-        self.assertEqual(myFov3.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov3.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov3.DECmaxDeg,np.degrees(3.0))
-        self.assertEqual(myFov3.DECminDeg,np.degrees(1.0))
+        myFov3 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov3.RA, 1.0)
+        self.assertEqual(myFov3.DEC, 2.0)
+        self.assertEqual(myFov3.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov3.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov3.DECmaxDeg, np.degrees(3.0))
+        self.assertEqual(myFov3.DECminDeg, np.degrees(1.0))
 
         length = np.array([1.0])
-        myFov4 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov4.RA,1.0)
-        self.assertEqual(myFov4.DEC,2.0)
-        self.assertEqual(myFov4.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov4.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov4.DECmaxDeg,np.degrees(3.0))
-        self.assertEqual(myFov4.DECminDeg,np.degrees(1.0))
+        myFov4 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov4.RA, 1.0)
+        self.assertEqual(myFov4.DEC, 2.0)
+        self.assertEqual(myFov4.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov4.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov4.DECmaxDeg, np.degrees(3.0))
+        self.assertEqual(myFov4.DECminDeg, np.degrees(1.0))
 
-        self.assertRaises(RuntimeError,SpatialBounds.getSpatialBounds,
-                          'utterNonsense',1.0,2.0,length)
+        self.assertRaises(RuntimeError, SpatialBounds.getSpatialBounds,
+                          'utterNonsense', 1.0, 2.0, length)
 
     def testRectangle(self):
 
-        length = [1.0,2.0]
-        myFov2 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov2.RA,1.0)
-        self.assertEqual(myFov2.DEC,2.0)
-        self.assertEqual(myFov2.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov2.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov2.DECmaxDeg,np.degrees(4.0))
-        self.assertEqual(myFov2.DECminDeg,np.degrees(0.0))
+        length = [1.0, 2.0]
+        myFov2 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov2.RA, 1.0)
+        self.assertEqual(myFov2.DEC, 2.0)
+        self.assertEqual(myFov2.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov2.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov2.DECmaxDeg, np.degrees(4.0))
+        self.assertEqual(myFov2.DECminDeg, np.degrees(0.0))
 
-        length = (1.0,2.0)
-        myFov3 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov3.RA,1.0)
-        self.assertEqual(myFov3.DEC,2.0)
-        self.assertEqual(myFov3.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov3.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov3.DECmaxDeg,np.degrees(4.0))
-        self.assertEqual(myFov3.DECminDeg,np.degrees(0.0))
+        length = (1.0, 2.0)
+        myFov3 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov3.RA, 1.0)
+        self.assertEqual(myFov3.DEC, 2.0)
+        self.assertEqual(myFov3.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov3.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov3.DECmaxDeg, np.degrees(4.0))
+        self.assertEqual(myFov3.DECminDeg, np.degrees(0.0))
 
-        length = np.array([1.0,2.0])
-        myFov4 = SpatialBounds.getSpatialBounds('box',1.0,2.0,length)
-        self.assertEqual(myFov4.RA,1.0)
-        self.assertEqual(myFov4.DEC,2.0)
-        self.assertEqual(myFov4.RAmaxDeg,np.degrees(2.0))
-        self.assertEqual(myFov4.RAminDeg,np.degrees(0.0))
-        self.assertEqual(myFov4.DECmaxDeg,np.degrees(4.0))
-        self.assertEqual(myFov4.DECminDeg,np.degrees(0.0))
+        length = np.array([1.0, 2.0])
+        myFov4 = SpatialBounds.getSpatialBounds('box', 1.0, 2.0, length)
+        self.assertEqual(myFov4.RA, 1.0)
+        self.assertEqual(myFov4.DEC, 2.0)
+        self.assertEqual(myFov4.RAmaxDeg, np.degrees(2.0))
+        self.assertEqual(myFov4.RAminDeg, np.degrees(0.0))
+        self.assertEqual(myFov4.DECmaxDeg, np.degrees(4.0))
+        self.assertEqual(myFov4.DECminDeg, np.degrees(0.0))
 
-        self.assertRaises(RuntimeError,SpatialBounds.getSpatialBounds,
-                          'box',1.0,2.0,'moreUtterNonsense')
+        self.assertRaises(RuntimeError, SpatialBounds.getSpatialBounds,
+                          'box', 1.0, 2.0, 'moreUtterNonsense')
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""
@@ -121,6 +122,7 @@ def suite():
     suites += unittest.makeSuite(SpatialBoundsTest)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit=False):
     """Run the tests"""

--- a/tests/testWcsUtils.py
+++ b/tests/testWcsUtils.py
@@ -66,13 +66,10 @@ class NativeLonLatTest(unittest.TestCase):
                                                        epoch=2000.0, includeRefraction=True)
 
             obsTemp = ObservationMetaData(mjd=mjd)
-            ra_temp, dec_temp = observedFromICRS(np.array([raPointing_icrs]),
-                                                 np.array([decPointing_icrs]),
-                                                 obs_metadata=obsTemp, epoch=2000.0,
-                                                 includeRefraction=True)
-
-            raPointing_obs = ra_temp[0]
-            decPointing_obs = dec_temp[0]
+            raPointing_obs, decPointing_obs = observedFromICRS(raPointing_icrs,
+                                                               decPointing_icrs,
+                                                               obs_metadata=obsTemp, epoch=2000.0,
+                                                               includeRefraction=True)
 
             for ra_obs, dec_obs, ra_icrs, dec_icrs in \
                 zip(raList_obs, decList_obs, raList_icrs, decList_icrs):
@@ -210,7 +207,7 @@ class NativeLonLatTest(unittest.TestCase):
 
 
 
-                rr_obs, dec_obs = observedFromICRS(np.array([rr]), np.array([dd]),
+                rr_obs, dec_obs = observedFromICRS(rr, dd,
                                                    obs_metadata=obs, epoch=2000.0, includeRefraction=True)
 
 

--- a/tests/testWcsUtils.py
+++ b/tests/testWcsUtils.py
@@ -8,6 +8,7 @@ from lsst.sims.utils import observedFromICRS, icrsFromObserved
 from lsst.sims.utils import ObservationMetaData, haversine
 from lsst.sims.utils import arcsecFromRadians, raDecFromAltAz, Site
 
+
 class NativeLonLatTest(unittest.TestCase):
 
     def testNativeLonLat(self):
@@ -22,13 +23,13 @@ class NativeLonLatTest(unittest.TestCase):
         decList_obs = [90.0, 90.0, 0.0, 0.0]
 
         raPointList_obs = [0.0, 270.0, 270.0, 0.0]
-        decPointList_obs = [0.0, 0.0,0.0, 0.0]
+        decPointList_obs = [0.0, 0.0, 0.0, 0.0]
 
         lonControlList = [180.0, 180.0, 90.0, 270.0]
         latControlList = [0.0, 0.0, 0.0, 0.0]
 
         for rr_obs, dd_obs, rp_obs, dp_obs, lonc, latc in \
-        zip(raList_obs, decList_obs, raPointList_obs, decPointList_obs, lonControlList, latControlList):
+            zip(raList_obs, decList_obs, raPointList_obs, decPointList_obs, lonControlList, latControlList):
 
             obsTemp = ObservationMetaData(mjd=mjd)
 
@@ -41,7 +42,6 @@ class NativeLonLatTest(unittest.TestCase):
             lon, lat = nativeLonLatFromRaDec(rr[0], dd[0], obs)
             distance = arcsecFromRadians(haversine(lon, lat, lonc, latc))
             self.assertLess(distance, 1.0)
-
 
     def testNativeLongLatComplicated(self):
         """
@@ -114,8 +114,8 @@ class NativeLonLatTest(unittest.TestCase):
 
                 # the x, y, z position of the star in the local coordinate basis
                 transformedPosition = np.array([-cosLat*sinLon,
-                                                   cosLat*cosLon,
-                                                   sinLat])
+                                                cosLat*cosLon,
+                                                sinLat])
 
                 # convert that position back into the un-rotated bases
                 testPosition = transformedPosition[0]*xAxis + \
@@ -126,8 +126,6 @@ class NativeLonLatTest(unittest.TestCase):
                 distance = np.sqrt(np.power(controlPosition-testPosition, 2).sum())
                 self.assertLess(distance, 1.0e-12)
 
-
-
     def testNativeLonLatVector(self):
         """
         Test that nativeLonLatFromRaDec works in a vectorized way; we do this
@@ -136,9 +134,6 @@ class NativeLonLatTest(unittest.TestCase):
         """
 
         obs = ObservationMetaData(pointingRA=123.0, pointingDec=43.0, mjd=53467.2)
-
-        raPoint = 145.0
-        decPoint = -35.0
 
         nSamples = 100
         np.random.seed(42)
@@ -154,7 +149,6 @@ class NativeLonLatTest(unittest.TestCase):
 
             self.assertLess(distance, 0.0001)
 
-
     def testRaDec(self):
         """
         Test that raDecFromNativeLonLat does invert
@@ -162,8 +156,9 @@ class NativeLonLatTest(unittest.TestCase):
         """
         np.random.seed(42)
         nSamples = 100
-        rrList = np.random.random_sample(nSamples)*50.0 # because raDecFromNativeLonLat is only good
-                                                           # out to a zenith distance of ~ 70 degrees
+        rrList = np.random.random_sample(nSamples)*50.0  # because raDecFromNativeLonLat is only good
+                                                         # out to a zenith distance of ~ 70 degrees
+
         thetaList = np.random.random_sample(nSamples)*2.0*np.pi
 
         rrPointingList = np.random.random_sample(10)*50.0
@@ -171,7 +166,8 @@ class NativeLonLatTest(unittest.TestCase):
         mjdList = np.random.random_sample(nSamples)*10000.0 + 43000.0
 
         for rrp, thetap, mjd in \
-        zip(rrPointingList, thetaPointingList, mjdList):
+            zip(rrPointingList, thetaPointingList, mjdList):
+
             site = Site(name='LSST')
             raZenith, decZenith = raDecFromAltAz(180.0, 0.0,
                                                  ObservationMetaData(mjd=mjd, site=site))
@@ -179,8 +175,6 @@ class NativeLonLatTest(unittest.TestCase):
             rp = raZenith + rrp*np.cos(thetap)
             dp = decZenith + rrp*np.sin(thetap)
             obs = ObservationMetaData(pointingRA=rp, pointingDec=dp, mjd=mjd, site=site)
-
-
 
             raList_icrs = (raZenith + rrList*np.cos(thetaList)) % 360.0
             decList_icrs = decZenith + rrList*np.sin(thetaList)
@@ -205,11 +199,8 @@ class NativeLonLatTest(unittest.TestCase):
                 distance = arcsecFromRadians(haversine(np.radians(r1), np.radians(d1),
                                                        np.radians(rr), np.radians(dd)))
 
-
-
                 rr_obs, dec_obs = observedFromICRS(rr, dd,
                                                    obs_metadata=obs, epoch=2000.0, includeRefraction=True)
-
 
                 # verify that the round trip through nativeLonLat only changed
                 # RA, Dec by less than an arcsecond
@@ -219,8 +210,6 @@ class NativeLonLatTest(unittest.TestCase):
                 # than the distance between the ICRS and the observed geocentric
                 # RA, Dec
                 self.assertLess(distance, dd_icrs_obs*0.01)
-
-
 
     def testRaDecVector(self):
         """
@@ -244,7 +233,6 @@ class NativeLonLatTest(unittest.TestCase):
                                                    np.radians(ra1), np.radians(dec1)))
             self.assertLess(distance, 0.1)
 
-
     def testDegreesVersusRadians(self):
         """
         Test that the radian and degree versions of nativeLonLatFromRaDec
@@ -266,7 +254,6 @@ class NativeLonLatTest(unittest.TestCase):
         raRad, decRad = _raDecFromNativeLonLat(np.radians(raList), np.radians(decList), obs)
         np.testing.assert_array_almost_equal(np.radians(raDeg), raRad, 15)
         np.testing.assert_array_almost_equal(np.radians(decDeg), decRad, 15)
-
 
 
 def suite():


### PR DESCRIPTION
This pull request incorporates the methods I drew up for the camera team to find the coordinates of the corners of specific chips into sims_coordUtils.  I took the opportunity to clean up a few things about the sims_coordUtils and sims_utils API.  Namely: there were several coordinate transformation methods that could only accept numpy arrays as inputs.  They could not accept single floats.  I fixed those methods so that they can accept either numpy arrays or floats.  I also standardized the names of args in the methods defined in sims_coordUtils/CameraUtils.py.

Like any good pull request, this had implications beyond sims_coordUtils.  There are pull requests in
sims_utils
sims_coordUtils
sims_catUtils
and sims_GalSimInterface
all of which must be built together.