### PR TITLE
Feature/sim 1789/mj dwarnings

### DIFF
--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -7,7 +7,25 @@ from astropy.utils.iers.iers import IERSRangeError
 
 from lsst.utils import getPackageDir
 
-__all__ = ["ModifiedJulianDate"]
+__all__ = ["ModifiedJulianDate", "MJDWarning", "UTCtoUT1Warning"]
+
+
+class MJDWarning(Warning):
+    """
+    A sub-class of Warning.  All of the warnings raised by ModifiedJulianDate
+    will be of this class (or its sub-classes), so that users can filter them
+    out by creating a simple filter targeted at category=MJDWarning.
+    """
+    pass
+
+class UTCtoUT1Warning(MJDWarning):
+    """
+    A sub-class of MJDWarning meant for use when astropy.Time cannot interpolate
+    UT1-UTC as a function of UTC because UTC is out of bounds of the data.
+    This class exists so that users can filter these warnings out by creating
+    a simple filter targeted at category=UTCtoUT1Warning.
+    """
+    pass
 
 class ModifiedJulianDate(object):
 
@@ -51,7 +69,8 @@ class ModifiedJulianDate(object):
         be interpolated on the IERS tables.
         """
         warnings.warn("UTC is outside of IERS table for UT1-UTC.\n"
-                      "Returning UT1 = UTC for lack of a better idea")
+                      "Returning UT1 = UTC for lack of a better idea",
+                      category=UTCtoUT1Warning)
 
     @property
     def TAI(self):

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -63,13 +63,16 @@ class ModifiedJulianDate(object):
     def __eq__(self, other):
         return self._time == other._time
 
-    def _warn_utc_out_of_bounds(self):
+    def _warn_utc_out_of_bounds(self, method_name):
         """
         Raise a standard warning if UTC is outside of the range that can
         be interpolated on the IERS tables.
+
+        method_name is the name of the method that caused this warning.
         """
         warnings.warn("UTC is outside of IERS table for UT1-UTC.\n"
-                      "Returning UT1 = UTC for lack of a better idea",
+                      "Returning UT1 = UTC for lack of a better idea\n"
+                      "This warning was caused by calling ModifiedJulianDate.%s\n" % method_name,
                       category=UTCtoUT1Warning)
 
     @property
@@ -104,7 +107,7 @@ class ModifiedJulianDate(object):
             try:
                 self._ut1 = self._time.ut1.mjd
             except IERSRangeError:
-                self._warn_utc_out_of_bounds()
+                self._warn_utc_out_of_bounds('UT1')
                 self._ut1 = self.UTC
 
         return self._ut1
@@ -124,7 +127,7 @@ class ModifiedJulianDate(object):
                 except:
                     self._dut1 = intermediate_value
             except IERSRangeError:
-                self._warn_utc_out_of_bounds()
+                self._warn_utc_out_of_bounds('dut1')
                 self._dut1 = 0.0
 
         return self._dut1

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -1,11 +1,7 @@
-import numpy as np
 import warnings
-import os
 
 from astropy.time import Time
 from astropy.utils.iers.iers import IERSRangeError
-
-from lsst.utils import getPackageDir
 
 __all__ = ["ModifiedJulianDate", "MJDWarning", "UTCtoUT1Warning"]
 
@@ -18,6 +14,7 @@ class MJDWarning(Warning):
     """
     pass
 
+
 class UTCtoUT1Warning(MJDWarning):
     """
     A sub-class of MJDWarning meant for use when astropy.Time cannot interpolate
@@ -27,8 +24,8 @@ class UTCtoUT1Warning(MJDWarning):
     """
     pass
 
-class ModifiedJulianDate(object):
 
+class ModifiedJulianDate(object):
 
     def __init__(self, TAI=None, UTC=None):
         """
@@ -59,7 +56,6 @@ class ModifiedJulianDate(object):
         self._ut1 = None
         self._dut1 = None
 
-
     def __eq__(self, other):
         return self._time == other._time
 
@@ -85,7 +81,6 @@ class ModifiedJulianDate(object):
 
         return self._tai
 
-
     @property
     def UTC(self):
         """
@@ -95,8 +90,6 @@ class ModifiedJulianDate(object):
             self._utc = self._time.utc.mjd
 
         return self._utc
-
-
 
     @property
     def UT1(self):
@@ -111,7 +104,6 @@ class ModifiedJulianDate(object):
                 self._ut1 = self.UTC
 
         return self._ut1
-
 
     @property
     def dut1(self):
@@ -132,7 +124,6 @@ class ModifiedJulianDate(object):
 
         return self._dut1
 
-
     @property
     def TT(self):
         """
@@ -142,7 +133,6 @@ class ModifiedJulianDate(object):
             self._tt = self._time.tt.mjd
 
         return self._tt
-
 
     @property
     def TDB(self):

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -137,14 +137,16 @@ class MjdTest(unittest.TestCase):
             mjd = ModifiedJulianDate(1000000.0)
             mjd.UT1
         self.assertEqual(len(w_list), 2)  # one MJDWarning; one ERFAWarning
-        self.assertEqual(w_list[1].category, UTCtoUT1Warning)
+        self.assertIsInstance(w_list[1].message, UTCtoUT1Warning)
+        self.assertIn('ModifiedJulianDate.UT1', w_list[1].message.message)
 
         with warnings.catch_warnings(record=True) as w_list:
             warnings.filterwarnings('always')
             mjd = ModifiedJulianDate(1000000.0)
             mjd.dut1
         self.assertEqual(len(w_list), 1)  # The ERFA warning is now suppressed
-        self.assertEqual(w_list[0].category, UTCtoUT1Warning)
+        self.assertIsInstance(w_list[0].message, UTCtoUT1Warning)
+        self.assertIn('ModifiedJulianDate.dut1', w_list[0].message.message)
 
 
 

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -3,12 +3,11 @@ import unittest
 import warnings
 import numpy as np
 import os
-import warnings
 import lsst.utils.tests as utilsTests
 
-import lsst.sims.utils as utils
 from lsst.utils import getPackageDir
 from lsst.sims.utils import ModifiedJulianDate, UTCtoUT1Warning
+
 
 class MjdTest(unittest.TestCase):
     """
@@ -18,7 +17,7 @@ class MjdTest(unittest.TestCase):
     testTimeTransformations.py
     """
 
-    longMessage=True
+    longMessage = True
 
     def test_tai_from_utc(self):
         """
@@ -47,7 +46,6 @@ class MjdTest(unittest.TestCase):
             self.assertLess(dd_sec, 5.0e-5, msg=msg)
             self.assertAlmostEqual(mjd.TAI, tt, 15, msg=msg)
 
-
     def test_tt(self):
         """
         Verify that Terrestrial Time is TAI + 32.184 seconds
@@ -66,7 +64,6 @@ class MjdTest(unittest.TestCase):
         for tai in tai_list:
             mjd = ModifiedJulianDate(TAI=tai)
             self.assertAlmostEqual(mjd.TT, tai+32.184/86400.0, 15)
-
 
     def test_tdb(self):
         """
@@ -87,9 +84,8 @@ class MjdTest(unittest.TestCase):
             mjd = ModifiedJulianDate(TAI=tai)
             g = np.radians(357.53 + 0.9856003*(np.round(tai-51544.5)))
             tdb_test = mjd.TT + (0.001658*np.sin(g) + 0.000014*np.sin(2.0*g))/86400.0
-            dt = np.abs(tdb_test-mjd.TDB)*8.64*1.0e10 # convert to microseconds
+            dt = np.abs(tdb_test-mjd.TDB)*8.64*1.0e10  # convert to microseconds
             self.assertLess(dt, 50)
-
 
     def test_dut1(self):
         """
@@ -118,14 +114,12 @@ class MjdTest(unittest.TestCase):
 
             self.assertLess(np.abs(mjd.dut1), 0.9)
 
-
     def test_eq(self):
         mjd1 = ModifiedJulianDate(TAI=43000.0)
         mjd2 = ModifiedJulianDate(TAI=43000.0)
         self.assertEqual(mjd1, mjd2)
         mjd3 = ModifiedJulianDate(TAI=43000.01)
         self.assertNotEqual(mjd1, mjd3)
-
 
     def test_warnings(self):
         """
@@ -149,7 +143,6 @@ class MjdTest(unittest.TestCase):
         self.assertIn('ModifiedJulianDate.dut1', w_list[0].message.message)
 
 
-
 def suite():
     """Returns a suite containing all the test cases in this module."""
     utilsTests.init()
@@ -157,6 +150,7 @@ def suite():
     suites += unittest.makeSuite(MjdTest)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit=False):
     """Run the tests"""

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -139,6 +139,14 @@ class MjdTest(unittest.TestCase):
         self.assertEqual(len(w_list), 2)  # one MJDWarning; one ERFAWarning
         self.assertEqual(w_list[1].category, UTCtoUT1Warning)
 
+        with warnings.catch_warnings(record=True) as w_list:
+            warnings.filterwarnings('always')
+            mjd = ModifiedJulianDate(1000000.0)
+            mjd.dut1
+        self.assertEqual(len(w_list), 1)  # The ERFA warning is now suppressed
+        self.assertEqual(w_list[0].category, UTCtoUT1Warning)
+
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -1,12 +1,14 @@
+from __future__ import with_statement
 import unittest
 import warnings
 import numpy as np
 import os
+import warnings
 import lsst.utils.tests as utilsTests
 
 import lsst.sims.utils as utils
 from lsst.utils import getPackageDir
-from lsst.sims.utils import ModifiedJulianDate
+from lsst.sims.utils import ModifiedJulianDate, UTCtoUT1Warning
 
 class MjdTest(unittest.TestCase):
     """
@@ -123,6 +125,19 @@ class MjdTest(unittest.TestCase):
         self.assertEqual(mjd1, mjd2)
         mjd3 = ModifiedJulianDate(TAI=43000.01)
         self.assertNotEqual(mjd1, mjd3)
+
+
+    def test_warnings(self):
+        """
+        Test that warnings raised when trying to interpolate UT1-UTC
+        for UTC too far in the future are of the type UTCtoUT1Warning
+        """
+
+        with warnings.catch_warnings(record=True) as w_list:
+            mjd = ModifiedJulianDate(1000000.0)
+            mjd.UT1
+        self.assertEqual(len(w_list), 2)  # one MJDWarning; one ERFAWarning
+        self.assertEqual(w_list[1].category, UTCtoUT1Warning)
 
 
 def suite():


### PR DESCRIPTION
Adds classes MJDWarning and UTCtoUT1Warning which are emitted when ModifiedJulianDate tries to calculate UT1 from a UTC value that is too far in the future for astropy to interpolate.  This should allow users to filter those warnings by targeting their filter at the classes, rather than having to write regexes for the specific warning messages.