### PR TITLE
Feature/sim 2049/speed up time

### DIFF
--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -113,11 +113,7 @@ class ModifiedJulianDate(object):
 
         if self._dut1 is None:
             try:
-                intermediate_value = self._time.get_delta_ut1_utc()
-                try:
-                    self._dut1 = intermediate_value.value
-                except:
-                    self._dut1 = intermediate_value
+                self._dut1 = self._time.delta_ut1_utc
             except IERSRangeError:
                 self._warn_utc_out_of_bounds('dut1')
                 self._dut1 = 0.0

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -56,6 +56,23 @@ class ModifiedJulianDate(object):
         self._ut1 = None
         self._dut1 = None
 
+    def _force_data(self, values):
+        """
+        Force the properties of this ModifiedJulianDate to have specific values.
+
+        values is a list of [TAI, UTC, TT, TDB, UT1, UT1-UTC] values.
+
+        This method exists so that, when instantiating lists of ModifiedJulianDates,
+        we can use astropy.time.Time's vectorized methods to quickly perform many
+        conversions at once.  Users should not try to use this method by hand.
+        """
+        self._tai = values[0]
+        self._utc = values[1]
+        self._tt = values[2]
+        self._tdb = values[3]
+        self._ut1 = values[4]
+        self._dut1 = values[5]
+
     def __eq__(self, other):
         return self._time == other._time
 

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -56,7 +56,7 @@ class ModifiedJulianDate(object):
         self._ut1 = None
         self._dut1 = None
 
-    def _force_data(self, values):
+    def _force_values(self, values):
         """
         Force the properties of this ModifiedJulianDate to have specific values.
 

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -51,12 +51,13 @@ class ModifiedJulianDate(object):
             good_dexes = np.where(np.logical_and(status != TIME_BEFORE_IERS_RANGE,
                                                  status != TIME_BEYOND_IERS_RANGE))
 
-            time_good = Time(UTC[good_dexes], scale='utc', format='mjd')
-            dut1_good = time_good.delta_ut1_utc
-            ut1_good = time_good.ut1.mjd
+            if len(good_dexes[0])>0:
+                time_good = Time(UTC[good_dexes], scale='utc', format='mjd')
+                dut1_good = time_good.delta_ut1_utc
+                ut1_good = time_good.ut1.mjd
 
-            ut1_out[good_dexes] = ut1_good
-            dut1_out[good_dexes] = dut1_good
+                ut1_out[good_dexes] = ut1_good
+                dut1_out[good_dexes] = dut1_good
 
         return ut1_out, dut1_out
 

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -51,7 +51,7 @@ class ModifiedJulianDate(object):
             good_dexes = np.where(np.logical_and(status != TIME_BEFORE_IERS_RANGE,
                                                  status != TIME_BEYOND_IERS_RANGE))
 
-            if len(good_dexes[0])>0:
+            if len(good_dexes[0]) > 0:
                 time_good = Time(UTC[good_dexes], scale='utc', format='mjd')
                 dut1_good = time_good.delta_ut1_utc
                 ut1_good = time_good.ut1.mjd

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -1,5 +1,6 @@
 import warnings
 import numpy as np
+import copy
 
 from astropy.time import Time
 from astropy.utils.iers.iers import IERSRangeError
@@ -126,10 +127,12 @@ class ModifiedJulianDate(object):
             self._time = Time(TAI, scale='tai', format='mjd')
             self._tai = TAI
             self._utc = None
+            self._initialized_with = 'TAI'
         else:
             self._time = Time(UTC, scale='utc', format='mjd')
             self._utc = UTC
             self._tai = None
+            self._initialized_with = 'UTC'
 
         self._tt = None
         self._tdb = None
@@ -155,6 +158,21 @@ class ModifiedJulianDate(object):
 
     def __eq__(self, other):
         return self._time == other._time
+
+    def __deepcopy__(self, memo):
+        if self._initialized_with == 'TAI':
+            new_mjd = ModifiedJulianDate(TAI=self.TAI)
+        else:
+            new_mjd = ModifiedJulianDate(UTC=self.UTC)
+
+        new_mjd._tai = copy.deepcopy(self._tai, memo)
+        new_mjd._utc = copy.deepcopy(self._utc, memo)
+        new_mjd._tt = copy.deepcopy(self._tt, memo)
+        new_mjd._tdb = copy.deepcopy(self._tdb, memo)
+        new_mjd._ut1 = copy.deepcopy(self._ut1, memo)
+        new_mjd._dut1 = copy.deepcopy(self._dut1, memo)
+
+        return new_mjd
 
     def _warn_utc_out_of_bounds(self, method_name):
         """

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -133,6 +133,9 @@ class MjdTest(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w_list:
             mjd = ModifiedJulianDate(1000000.0)
+            # clear the warning registry, in case a previous test raised the warnings
+            # we are looking for
+            mjd._warn_utc_out_of_bounds.__globals__['__warningregistry__'].clear()
             mjd.UT1
         self.assertEqual(len(w_list), 2)  # one MJDWarning; one ERFAWarning
         self.assertIsInstance(w_list[1].message, UTCtoUT1Warning)

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -122,17 +122,14 @@ class MjdTest(unittest.TestCase):
         mjd3 = ModifiedJulianDate(TAI=43000.01)
         self.assertNotEqual(mjd1, mjd3)
 
+    @unittest.skipIf(astropy.__version__ >= '1.2',
+                     "astropy 1.2 handles cases of dates too far in the future "
+                     "on its own in a graceful manner. Our warning classes are not needed")
     def test_warnings(self):
         """
         Test that warnings raised when trying to interpolate UT1-UTC
         for UTC too far in the future are of the type UTCtoUT1Warning
         """
-
-        if astropy.__version__ >= '1.2':
-            # astropy 1.2 handles cases of dates too far in the future
-            # on its own in a graceful manner.  Skip this test if the
-            # version of astropy you are running is >= 1.2
-            return
 
         with warnings.catch_warnings(record=True) as w_list:
             mjd = ModifiedJulianDate(1000000.0)

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -146,6 +146,31 @@ class MjdTest(unittest.TestCase):
         self.assertIsInstance(w_list[0].message, UTCtoUT1Warning)
         self.assertIn('ModifiedJulianDate.dut1', w_list[0].message.message)
 
+    def test_force_data(self):
+        """
+        Test that we can force the properties of a ModifiedJulianDate to have
+        specific values
+        """
+        tt = ModifiedJulianDate(TAI=59580.0)
+        values = np.arange(6)
+        tt._force_data(values)
+        self.assertEqual(tt.TAI, 0.0)
+        self.assertEqual(tt.UTC, 1.0)
+        self.assertEqual(tt.TT, 2.0)
+        self.assertEqual(tt.TDB, 3.0)
+        self.assertEqual(tt.UT1, 4.0)
+        self.assertEqual(tt.dut1, 5.0)
+
+        tt = ModifiedJulianDate(UTC=59580.0)
+        values = 2.0*np.arange(6)
+        tt._force_data(values)
+        self.assertEqual(tt.TAI, 0.0)
+        self.assertEqual(tt.UTC, 2.0)
+        self.assertEqual(tt.TT, 4.0)
+        self.assertEqual(tt.TDB, 6.0)
+        self.assertEqual(tt.UT1, 8.0)
+        self.assertEqual(tt.dut1, 10.0)
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -4,6 +4,7 @@ import unittest
 import warnings
 import numpy as np
 import os
+import copy
 import lsst.utils.tests as utilsTests
 
 from lsst.utils import getPackageDir
@@ -150,6 +151,25 @@ class MjdTest(unittest.TestCase):
         self.assertEqual(mjd1, mjd2)
         mjd3 = ModifiedJulianDate(TAI=43000.01)
         self.assertNotEqual(mjd1, mjd3)
+
+    def test_deepcopy(self):
+        mjd1 = ModifiedJulianDate(TAI=43590.0)
+        mjd1.dut1
+        deep_mjd2 = copy.deepcopy(mjd1)
+        self.assertEqual(mjd1, deep_mjd2)
+        self.assertNotEqual(mjd1.__repr__(), deep_mjd2.__repr__())
+        equiv_mjd2 = mjd1
+        self.assertEqual(mjd1, equiv_mjd2)
+        self.assertEqual(mjd1.__repr__(), equiv_mjd2.__repr__())
+
+        mjd1 = ModifiedJulianDate(UTC=43590.0)
+        mjd1.dut1
+        deep_mjd2 = copy.deepcopy(mjd1)
+        self.assertEqual(mjd1, deep_mjd2)
+        self.assertNotEqual(mjd1.__repr__(), deep_mjd2.__repr__())
+        equiv_mjd2 = mjd1
+        self.assertEqual(mjd1, equiv_mjd2)
+        self.assertEqual(mjd1.__repr__(), equiv_mjd2.__repr__())
 
     @unittest.skipIf(astropy.__version__ >= '1.2',
                      "astropy 1.2 handles cases of dates too far in the future "

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -246,6 +246,22 @@ class MjdTest(unittest.TestCase):
             self.assertAlmostEqual(mjd.TDB, control.TDB, tol, msg=msg)
             self.assertAlmostEqual(mjd.dut1, control.dut1, tol, msg=msg)
 
+        # Now test the case where we only have dates in the future (this
+        # is an edge case since good_dexes in ModifiedJulianDate._get_ut1_from_utc
+        # will have len = 0
+        tai_list = 60000.0 + 10000.0*rng.random_sample(20)
+        mjd_list = ModifiedJulianDate.get_list(TAI=tai_list)
+        for tai, mjd in zip(tai_list, mjd_list):
+            msg = "Offending TAI: %f" % tai
+            control = ModifiedJulianDate(TAI=tai)
+            self.assertAlmostEqual(mjd.TAI, tai, 11, msg=msg)
+            self.assertAlmostEqual(mjd.TAI, control.TAI, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UTC, control.UTC, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UT1, control.UT1, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TT, control.TT, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TDB, control.TDB, tol, msg=msg)
+            self.assertAlmostEqual(mjd.dut1, control.dut1, tol, msg=msg)
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -171,6 +171,38 @@ class MjdTest(unittest.TestCase):
         self.assertEqual(tt.UT1, 8.0)
         self.assertEqual(tt.dut1, 10.0)
 
+    def test_list(self):
+        """
+        Test that ModifiedJulianDate.get_list() gets results that are consistent
+        with creating a list of ModifiedJulianDates by hand.
+        """
+
+        rng = np.random.RandomState(88)
+
+        tai_list = 40000.0 + 10000.0*rng.random_sample(20)
+        mjd_list = ModifiedJulianDate.get_list(TAI=tai_list)
+        for tai, mjd in zip(tai_list, mjd_list):
+            control = ModifiedJulianDate(TAI=tai)
+            self.assertEqual(mjd.TAI, tai)
+            self.assertEqual(mjd.TAI, control.TAI)
+            self.assertEqual(mjd.UTC, control.UTC)
+            self.assertEqual(mjd.UT1, control.UT1)
+            self.assertEqual(mjd.TT, control.TT)
+            self.assertEqual(mjd.TDB, control.TDB)
+            self.assertEqual(mjd.dut1, control.dut1)
+
+        utc_list = 40000.0 + 10000.0*rng.random_sample(20)
+        mjd_list = ModifiedJulianDate.get_list(UTC=utc_list)
+        for utc, mjd in zip(utc_list, mjd_list):
+            control = ModifiedJulianDate(UTC=utc)
+            self.assertEqual(mjd.UTC, utc)
+            self.assertEqual(mjd.TAI, control.TAI)
+            self.assertEqual(mjd.UTC, control.UTC)
+            self.assertEqual(mjd.UT1, control.UT1)
+            self.assertEqual(mjd.TT, control.TT)
+            self.assertEqual(mjd.TDB, control.TDB)
+            self.assertEqual(mjd.dut1, control.dut1)
+
 
 def suite():
     """Returns a suite containing all the test cases in this module."""

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -90,7 +90,8 @@ class MjdTest(unittest.TestCase):
 
     def test_dut1(self):
         """
-        Test that UT1 is within 0.9 seconds of UTC.
+        Test that UT1 is within 0.9 seconds of UTC and that dut1 is equal
+        to UT1-UTC to within a microsecond.
 
         (Because calculating UT1-UTC requires loading a lookup
         table, we will just do this somewhat gross unit test to
@@ -117,8 +118,8 @@ class MjdTest(unittest.TestCase):
 
     def test_dut1_future(self):
         """
-        Test that UT1 is within 0.9 seconds of UTC.  Consider times far
-        in the future.
+        Test that UT1 is within 0.9 seconds of UTC and that dut1 is equal
+        to UT1-UTC to within a microsecond.  Consider times far in the future.
 
         (Because calculating UT1-UTC requires loading a lookup
         table, we will just do this somewhat gross unit test to

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -115,6 +115,34 @@ class MjdTest(unittest.TestCase):
 
             self.assertLess(np.abs(mjd.dut1), 0.9)
 
+    def test_dut1_future(self):
+        """
+        Test that UT1 is within 0.9 seconds of UTC.  Consider times far
+        in the future.
+
+        (Because calculating UT1-UTC requires loading a lookup
+        table, we will just do this somewhat gross unit test to
+        make sure that the astropy.time API doesn't change out
+        from under us in some weird way... for instance, returning
+        dut in units of days rather than seconds, etc.)
+        """
+
+        np.random.seed(117)
+
+        utc_list = np.random.random_sample(1000)*10000.0 + 63000.0
+        for utc in utc_list:
+            mjd = ModifiedJulianDate(UTC=utc)
+
+            # first, test the self-consistency of ModifiedJulianData.dut1
+            # and ModifiedJulianData.UT1-ModifiedJulianData.UTC
+            #
+            # this only works for days on which a leap second is not applied
+            dt = (mjd.UT1-mjd.UTC)*86400.0
+
+            self.assertAlmostEqual(dt, mjd.dut1, 6)
+
+            self.assertLess(np.abs(mjd.dut1), 0.9)
+
     def test_eq(self):
         mjd1 = ModifiedJulianDate(TAI=43000.0)
         mjd2 = ModifiedJulianDate(TAI=43000.0)

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -153,11 +153,15 @@ class MjdTest(unittest.TestCase):
         self.assertNotEqual(mjd1, mjd3)
 
     def test_deepcopy(self):
+        # make sure that deepcopy() creates identical
+        # ModifiedJulianDates with different memory addresses
         mjd1 = ModifiedJulianDate(TAI=43590.0)
         mjd1.dut1
         deep_mjd2 = copy.deepcopy(mjd1)
         self.assertEqual(mjd1, deep_mjd2)
         self.assertNotEqual(mjd1.__repr__(), deep_mjd2.__repr__())
+        self.assertEqual(mjd1.TAI, deep_mjd2.TAI)
+        self.assertEqual(mjd1.dut1, deep_mjd2.dut1)
         equiv_mjd2 = mjd1
         self.assertEqual(mjd1, equiv_mjd2)
         self.assertEqual(mjd1.__repr__(), equiv_mjd2.__repr__())
@@ -166,10 +170,30 @@ class MjdTest(unittest.TestCase):
         mjd1.dut1
         deep_mjd2 = copy.deepcopy(mjd1)
         self.assertEqual(mjd1, deep_mjd2)
+        self.assertEqual(mjd1.UTC, deep_mjd2.UTC)
+        self.assertEqual(mjd1.dut1, deep_mjd2.dut1)
         self.assertNotEqual(mjd1.__repr__(), deep_mjd2.__repr__())
         equiv_mjd2 = mjd1
         self.assertEqual(mjd1, equiv_mjd2)
         self.assertEqual(mjd1.__repr__(), equiv_mjd2.__repr__())
+
+        # make sure that deepcopy() still works, even if you have called
+        # all of the original ModifiedJulianDate's properties
+        mjd1 = ModifiedJulianDate(TAI=42590.0)
+        mjd1.UTC
+        mjd1.dut1
+        mjd1.UT1
+        mjd1.TT
+        mjd1.TDB
+        mjd2 = copy.deepcopy(mjd1)
+        self.assertEqual(mjd1.TAI, mjd2.TAI)
+        self.assertEqual(mjd1.UTC, mjd2.UTC)
+        self.assertEqual(mjd1.dut1, mjd2.dut1)
+        self.assertEqual(mjd1.UT1, mjd2.UT1)
+        self.assertEqual(mjd1.TT, mjd2.TT)
+        self.assertEqual(mjd1.TDB, mjd2.TDB)
+        self.assertEqual(mjd1, mjd2)
+        self.assertNotEqual(mjd1.__repr__(), mjd2.__repr__())
 
     @unittest.skipIf(astropy.__version__ >= '1.2',
                      "astropy 1.2 handles cases of dates too far in the future "

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -146,14 +146,14 @@ class MjdTest(unittest.TestCase):
         self.assertIsInstance(w_list[0].message, UTCtoUT1Warning)
         self.assertIn('ModifiedJulianDate.dut1', w_list[0].message.message)
 
-    def test_force_data(self):
+    def test_force_values(self):
         """
         Test that we can force the properties of a ModifiedJulianDate to have
         specific values
         """
         tt = ModifiedJulianDate(TAI=59580.0)
         values = np.arange(6)
-        tt._force_data(values)
+        tt._force_values(values)
         self.assertEqual(tt.TAI, 0.0)
         self.assertEqual(tt.UTC, 1.0)
         self.assertEqual(tt.TT, 2.0)
@@ -163,7 +163,7 @@ class MjdTest(unittest.TestCase):
 
         tt = ModifiedJulianDate(UTC=59580.0)
         values = 2.0*np.arange(6)
-        tt._force_data(values)
+        tt._force_values(values)
         self.assertEqual(tt.TAI, 0.0)
         self.assertEqual(tt.UTC, 2.0)
         self.assertEqual(tt.TT, 4.0)

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -165,17 +165,23 @@ class MjdTest(unittest.TestCase):
             # we are looking for
             mjd._warn_utc_out_of_bounds.__globals__['__warningregistry__'].clear()
             mjd.UT1
-        self.assertEqual(len(w_list), 2)  # one MJDWarning; one ERFAWarning
-        self.assertIsInstance(w_list[1].message, UTCtoUT1Warning)
-        self.assertIn('ModifiedJulianDate.UT1', w_list[1].message.message)
+        expected_warnings = 0
+        for ww in w_list:
+            if isinstance(ww.message, UTCtoUT1Warning):
+                if 'ModifiedJulianDate.UT1' in ww.message.message:
+                    expected_warnings += 1
+        self.assertGreater(expected_warnings, 0, msg="UT1 did not emit a UTCtoUT1Warning")
 
+        expected_warnings = 0
         with warnings.catch_warnings(record=True) as w_list:
             warnings.filterwarnings('always')
             mjd = ModifiedJulianDate(1000000.0)
             mjd.dut1
-        self.assertEqual(len(w_list), 1)  # The ERFA warning is now suppressed
-        self.assertIsInstance(w_list[0].message, UTCtoUT1Warning)
-        self.assertIn('ModifiedJulianDate.dut1', w_list[0].message.message)
+        for ww in w_list:
+            if isinstance(ww.message, UTCtoUT1Warning):
+                if 'ModifiedJulianDate.dut1' in ww.message.message:
+                    expected_warnings += 1
+        self.assertGreater(expected_warnings, 0, msg="dut1 did not emit a UTCtoUT1Warning")
 
     def test_force_values(self):
         """

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -215,30 +215,35 @@ class MjdTest(unittest.TestCase):
         """
 
         rng = np.random.RandomState(88)
+        tol = 10  # decimal place tolerance
 
         tai_list = 40000.0 + 10000.0*rng.random_sample(20)
+        tai_list = np.append(tai_list, 59580.0 + 10000.0*rng.random_sample(20))
         mjd_list = ModifiedJulianDate.get_list(TAI=tai_list)
         for tai, mjd in zip(tai_list, mjd_list):
+            msg = "Offending TAI: %f" % tai
             control = ModifiedJulianDate(TAI=tai)
-            self.assertEqual(mjd.TAI, tai)
-            self.assertEqual(mjd.TAI, control.TAI)
-            self.assertEqual(mjd.UTC, control.UTC)
-            self.assertEqual(mjd.UT1, control.UT1)
-            self.assertEqual(mjd.TT, control.TT)
-            self.assertEqual(mjd.TDB, control.TDB)
-            self.assertEqual(mjd.dut1, control.dut1)
+            self.assertAlmostEqual(mjd.TAI, tai, 11, msg=msg)
+            self.assertAlmostEqual(mjd.TAI, control.TAI, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UTC, control.UTC, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UT1, control.UT1, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TT, control.TT, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TDB, control.TDB, tol, msg=msg)
+            self.assertAlmostEqual(mjd.dut1, control.dut1, tol, msg=msg)
 
         utc_list = 40000.0 + 10000.0*rng.random_sample(20)
+        utc_list = np.append(utc_list, 59580.0 + 10000.0*rng.random_sample(20))
         mjd_list = ModifiedJulianDate.get_list(UTC=utc_list)
         for utc, mjd in zip(utc_list, mjd_list):
+            msg = "Offending UTC: %f" % utc
             control = ModifiedJulianDate(UTC=utc)
-            self.assertEqual(mjd.UTC, utc)
-            self.assertEqual(mjd.TAI, control.TAI)
-            self.assertEqual(mjd.UTC, control.UTC)
-            self.assertEqual(mjd.UT1, control.UT1)
-            self.assertEqual(mjd.TT, control.TT)
-            self.assertEqual(mjd.TDB, control.TDB)
-            self.assertEqual(mjd.dut1, control.dut1)
+            self.assertAlmostEqual(mjd.UTC, utc, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TAI, control.TAI, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UTC, control.UTC, tol, msg=msg)
+            self.assertAlmostEqual(mjd.UT1, control.UT1, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TT, control.TT, tol, msg=msg)
+            self.assertAlmostEqual(mjd.TDB, control.TDB, tol, msg=msg)
+            self.assertAlmostEqual(mjd.dut1, control.dut1, tol, msg=msg)
 
 
 def suite():


### PR DESCRIPTION
It has been noted that converting RA, Dec to Alt, Az for many different dates is quite slow.  This is because all of the time spent converting TAI to the other time scales used by the PALPY coordinate methods.  This pull request adds a class method get_list() to ModifiedJulianDate which takes a list of MJDs and uses astropy.time to create a list of ModifiedJulianDate instantiations in a vectorized fashion (pre-computing all of the time scale transformations).  This could be used to speed up the RA, Dec to Alt, Az transformations as follows

```
tai_list = rng.random_sample(n_samples)*1000.0+59580.0
mjd_list = ModifiedJulianDate.get_list(TAI=tai_list)

ra_list = rng.random_sample(n_samples)*360.0
dec_list = (rng.random_sample(n_samples)-0.5)*180.0
rot_list = rng.random_sample(n_samples)*360.0

obs_list = []
for rr, dd, rt, mjd in zip(ra_list, dec_list, rot_list, mjd_list):
    obs = ObservationMetaData(pointingRA=rr, pointingDec=dd,
                                  rotSkyPos=rt, mjd=mjd)
    # Note that we are passing ModifiedJulianDates that were instantiated
    # by ModifiedJulianDate.get_list() directly into ObservationMetaData

    obs_list.append(obs)

    
alt = 45.0
az = 112.0
    
ra_list = []
dec_list = []
for obs in obs_list:
    ra, dec = raDecFromAltAz(alt, az, obs)
    ra_list.append(ra)
    dec_list.append(dec)
```
Tests show this to be an order of magnitude faster than the old set up (where each ObservationMetaData created its own ModifiedJulianDate from a TAI value).