### PR TITLE
Feature/sim 2096/phosim interface

### DIFF
--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -695,10 +695,6 @@ def _calculateObservatoryParameters(obs_metadata, wavelength, includeRefraction)
     # converting apparent place into observed place
     # i.e. it calculates geodetic latitude, magnitude of diurnal aberration,
     # refraction coefficients and the like based on data about the observation site
-    #
-    # TODO: palpy.aoppa requires as its first argument
-    # the UTC time expressed as an MJD.  It is not clear to me
-    # how to actually calculate that.
     if includeRefraction:
         obsPrms = palpy.aoppa(obs_metadata.mjd.UTC, obs_metadata.mjd.dut1,
                               obs_metadata.site.longitude_rad,

--- a/python/lsst/sims/utils/CompoundCoordinateTransformations.py
+++ b/python/lsst/sims/utils/CompoundCoordinateTransformations.py
@@ -95,7 +95,7 @@ def _altAzPaFromRaDec(raRad, decRad, obs, includeRefraction=True):
     return alt, az, pa
 
 
-def raDecFromAltAz(alt, az, obs):
+def raDecFromAltAz(alt, az, obs, includeRefraction=True):
     """
     Convert altitude and azimuth to RA and Dec
 
@@ -106,6 +106,9 @@ def raDecFromAltAz(alt, az, obs):
     @param [in] obs is an ObservationMetaData characterizing
     the site of the telescope and the MJD of the observation
 
+    @param [in] includeRefraction is a boolean that turns refraction on and off
+    (default True)
+
     @param [out] RA in degrees (in the International Celestial Reference System)
 
     @param [out] Dec in degrees (in the International Celestial Reference System)
@@ -113,12 +116,13 @@ def raDecFromAltAz(alt, az, obs):
     Note: This method is only accurate to within 0.01 arcsec near azimuth = 0 or pi
     """
 
-    ra, dec = _raDecFromAltAz(np.radians(alt), np.radians(az), obs)
+    ra, dec = _raDecFromAltAz(np.radians(alt), np.radians(az), obs,
+                              includeRefraction=includeRefraction)
 
     return np.degrees(ra), np.degrees(dec)
 
 
-def _raDecFromAltAz(altRad, azRad, obs):
+def _raDecFromAltAz(altRad, azRad, obs, includeRefraction=True):
     """
     Convert altitude and azimuth to RA and Dec
 
@@ -128,6 +132,9 @@ def _raDecFromAltAz(altRad, azRad, obs):
 
     @param [in] obs is an ObservationMetaData characterizing
     the site of the telescope and the MJD of the observation
+
+    @param [in] includeRefraction is a boolean that turns refraction on and off
+    (default True)
 
     @param [out] RA in radians (in the International Celestial Reference System)
 
@@ -167,7 +174,7 @@ def _raDecFromAltAz(altRad, azRad, obs):
 
     raRad, decRad = _icrsFromObserved(raObs, decObs,
                                       obs_metadata=obs, epoch=2000.0,
-                                      includeRefraction=True)
+                                      includeRefraction=includeRefraction)
 
     return raRad, decRad
 

--- a/python/lsst/sims/utils/CompoundCoordinateTransformations.py
+++ b/python/lsst/sims/utils/CompoundCoordinateTransformations.py
@@ -17,7 +17,7 @@ __all__ = ["_altAzPaFromRaDec", "altAzPaFromRaDec",
            "getRotSkyPos", "_getRotSkyPos"]
 
 
-def altAzPaFromRaDec(ra, dec, obs):
+def altAzPaFromRaDec(ra, dec, obs, includeRefraction=True):
     """
     Convert RA, Dec, longitude, latitude and MJD into altitude, azimuth
     and parallactic angle using PALPY
@@ -31,6 +31,9 @@ def altAzPaFromRaDec(ra, dec, obs):
     @param [in] obs is an ObservationMetaData characterizing
     the site of the telescope and the MJD of the observation
 
+    @param [in] includeRefraction is a boolean that turns refraction on and off
+    (default True)
+
     @param [out] altitude in degrees
 
     @param [out] azimuth in degrees
@@ -39,12 +42,12 @@ def altAzPaFromRaDec(ra, dec, obs):
     """
 
     alt, az, pa = _altAzPaFromRaDec(np.radians(ra), np.radians(dec),
-                                    obs)
+                                    obs, includeRefraction=includeRefraction)
 
     return np.degrees(alt), np.degrees(az), np.degrees(pa)
 
 
-def _altAzPaFromRaDec(raRad, decRad, obs):
+def _altAzPaFromRaDec(raRad, decRad, obs, includeRefraction=True):
     """
     Convert RA, Dec, longitude, latitude and MJD into altitude, azimuth
     and parallactic angle using PALPY
@@ -58,6 +61,9 @@ def _altAzPaFromRaDec(raRad, decRad, obs):
     @param [in] obs is an ObservationMetaData characterizing
     the site of the telescope and the MJD of the observation
 
+    @param [in] includeRefraction is a boolean that turns refraction on and off
+    (default True)
+
     @param [out] altitude in radians
 
     @param [out] azimuth in radians
@@ -68,8 +74,9 @@ def _altAzPaFromRaDec(raRad, decRad, obs):
     are_arrays = _validate_inputs([raRad, decRad], ['ra', 'dec'],
                                   "altAzPaFromRaDec")
 
-    raObs, decObs = _observedFromICRS(
-        raRad, decRad, obs_metadata=obs, epoch=2000.0, includeRefraction=True)
+    raObs, decObs = \
+    _observedFromICRS(raRad, decRad, obs_metadata=obs,
+                      epoch=2000.0, includeRefraction=includeRefraction)
 
     lst = calcLmstLast(obs.mjd.UT1, obs.site.longitude_rad)
     last = lst[1]

--- a/python/lsst/sims/utils/ObservationMetaData.py
+++ b/python/lsst/sims/utils/ObservationMetaData.py
@@ -109,7 +109,7 @@ class ObservationMetaData(object):
         self._skyBrightness = skyBrightness
         self._site = site
         self._epoch = epoch
-        self._phoSimMetadata = {}
+        self._OpsimMetaData = None
 
         if mjd is not None:
             if isinstance(mjd, numbers.Number):
@@ -169,7 +169,7 @@ class ObservationMetaData(object):
         mydict['skyBrightness'] = self.skyBrightness
         # mydict['m5'] = self.m5
 
-        mydict['phoSimMetaData'] = self._phoSimMetadata
+        mydict['OpsimMetaData'] = self._OpsimMetaData
 
         return mydict
 
@@ -253,28 +253,6 @@ class ObservationMetaData(object):
 
         self._bounds = SpatialBounds.getSpatialBounds(self._boundType, self._pointingRA, self._pointingDec,
                                                       self._boundLength)
-
-    def assignPhoSimMetaData(self, metadata):
-        """
-        Assign a dict of extra metadata assumed by PhoSim.
-
-        Optional values that can be included in this dict
-        are:
-
-        SIM_SEED -- an int used to seed a random number generator in PhoSim
-        Opsim_moonra -- RA of the moon in degrees
-        Opsim_moondec -- Dec of the moon in degrees
-        Opsim_rawseeing -- seeing at zenith at 500 nm
-        Opsim_sunalt -- altitude of the sun in degrees
-        Opsim_moonalt -- altitude of the moon in degrees
-        Opsim_dist2moon -- distance from the pointing to the moon in degrees
-        Opsim_moonphase -- phase of the moon from 0 to 100
-        exptime -- exposure time
-
-        None of these entries is required.  No effort is made to ensure that they
-        are consistent with the other data contained in this ObservationMetaData.
-        """
-        self._phoSimMetadata = metadata
 
     @property
     def pointingRA(self):
@@ -468,13 +446,15 @@ class ObservationMetaData(object):
         self._skyBrightness = value
 
     @property
-    def phoSimMetaData(self):
+    def OpsimMetaData(self):
         """
-        A dict of parameters expected by PhoSim characterizing this
-        ObservationMetaData.
+        A dict of all of the columns taken from OpSim when constructing this
+        ObservationMetaData
         """
-        return self._phoSimMetadata
+        return self._OpsimMetaData
 
-    @phoSimMetaData.setter
-    def phoSimMetaData(self, value):
-        self.assignPhoSimMetaData(value)
+    @OpsimMetaData.setter
+    def OpsimMetaData(self, value):
+        if not isinstance(value, dict):
+            raise RuntimeError('OpsimMetaData must be a dict')
+        self._OpsimMetaData = value

--- a/python/lsst/sims/utils/fileMaps.py
+++ b/python/lsst/sims/utils/fileMaps.py
@@ -67,7 +67,7 @@ class SpecMap(object):
 
         raise KeyError("No path found for spectrum name: %s" % (item))
 
-    def has_key(self, item):
+    def __contains__(self, item):
         """
         Returns True if there is a map for 'item'; False if not.
 

--- a/tests/testAstrometry.py
+++ b/tests/testAstrometry.py
@@ -1015,7 +1015,7 @@ class astrometryUnitTest(unittest.TestCase):
         n_samples = 10
         for i_batch in range(n_batches):
             _d_sun = 0.0
-            while _d_sun < 0.25*np.pi:
+            while _d_sun < 0.25*np.pi:  # because ICRS -> Observed conversion breaks close to the sun
                 mjd = rng.random_sample(1)[0]*10000.0 + 40000.0
                 obs = ObservationMetaData(mjd=mjd)
                 ra_in = rng.random_sample(n_samples)*np.pi*2.0

--- a/tests/testFileMaps.py
+++ b/tests/testFileMaps.py
@@ -171,6 +171,18 @@ class SpecMapTest(unittest.TestCase):
         self.verifyFile('L2_0Full.dat', 'starSED/old_mlt', testSpecMap=testMap)
         self.verifyFile('m5.1Full.dat', 'starSED/old_mlt', testSpecMap=testMap)
 
+    def test_contains(self):
+        """
+        Test that 'k in SpecMap' works as it should
+        """
+
+        testMap = SpecMap(fileDict={'abcd.txt': 'file_dir/abcd.txt.gz'},
+                          dirDict={'(^burrows)': 'dir_dir'})
+
+        self.assertFalse('banana' in testMap)
+        self.assertTrue('abcd.txt' in testMap)
+        self.assertTrue('burrows_123.txt' in testMap)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -262,6 +262,31 @@ class ObservationMetaDataTest(unittest.TestCase):
         obs = ObservationMetaData()
         obs.summary
 
+    def testOpsimMetaData(self):
+        """
+        Make sure that an exception is raised if you pass a non-dict
+        object in as OpsimMetaData
+        """
+        obs = ObservationMetaData(pointingRA=23.0, pointingDec=-11.0)
+
+        with self.assertRaises(RuntimeError) as ee:
+            obs.OpsimMetaData = 5.0
+        self.assertIn("must be a dict", ee.exception.args[0])
+
+        with self.assertRaises(RuntimeError) as ee:
+            obs.OpsimMetaData = 5
+        self.assertIn("must be a dict", ee.exception.args[0])
+
+        with self.assertRaises(RuntimeError) as ee:
+            obs.OpsimMetaData = [5.0, 3.0]
+        self.assertIn("must be a dict", ee.exception.args[0])
+
+        with self.assertRaises(RuntimeError) as ee:
+            obs.OpsimMetaData = (5.0, 3.0)
+        self.assertIn("must be a dict", ee.exception.args[0])
+
+        obs.OpsimMetaData = {'a': 1, 'b': 2}
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
A new PhoSim InstanceCatalog API has been published here

https://bitbucket.org/phosim/phosim_release/wiki/Instance%20Catalog

This required a re-working of our CatSim-PhoSim interface.  Under this pull request, whenever a user creates an ObservationMetaData using the ObservationMetaDataGenerator, all of the OpSim columns associated with the pointing will be stored in a dict called `OpsimMetaData`.  The mapping between these OpSim columns and the header parameters expected by PhoSim will be handled by a dict called `phoSimHeaderMap` which is assigned to the InstanceCatalog before writing it.  If no `phoSimHeaderMap` is specified, an error is thrown whose message explains the way the header map should work.  Even if users do not want to map any extra columns (i.e. anything beyond RA, Dec, Alt, Az, MJD, rotSkyPos, and filter, which ObservationMetaData handles automatically), they must specify an empty dict as the `phoSimHeaderMap`.  This is to prevent users from doing something they did not intend (since PhoSim will accept nonsense or incomplete header parameters without failing).

This required changes to

sims_utils
sims_catalogs
sims_catUtils
sims_GalSimInterface