### PR TITLE
Bugfix/sim 2222/remove icrs from

### DIFF
--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -483,7 +483,7 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
         include_px = True
 
         if isinstance(ra, np.ndarray):
-            fill_value = np.zeros(len(ra))
+            fill_value = np.zeros(len(ra), dtype=float)
         else:
             fill_value = 0.0
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -475,27 +475,37 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     if mjd is None:
         raise RuntimeError("cannot call appGeoFromICRS; mjd is None")
 
-    if isinstance(ra, np.ndarray):
-        fill_value = np.zeros(len(ra))
+    include_px = False
+
+    if (pm_ra is not None or pm_dec is not None or
+        v_rad is not None or parallax is not None):
+
+        include_px = True
+
+        if isinstance(ra, np.ndarray):
+            fill_value = np.zeros(len(ra))
+        else:
+            fill_value = 0.0
+
+        if pm_ra is None:
+            pm_ra = fill_value
+
+        if pm_dec is None:
+            pm_dec = fill_value
+
+        if v_rad is None:
+            v_rad = fill_value
+
+        if parallax is None:
+            parallax = fill_value
+
+        are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, v_rad, parallax],
+                                      ['ra', 'dec', 'pm_ra', 'pm_dec', 'v_rad',
+                                       'parallax'],
+                                      "appGeoFromICRS")
     else:
-        fill_value = 0.0
+        are_arrays = _validate_inputs([ra, dec], ['ra', 'dec'], "appGeoFromICRS")
 
-    if pm_ra is None:
-        pm_ra = fill_value
-
-    if pm_dec is None:
-        pm_dec = fill_value
-
-    if v_rad is None:
-        v_rad = fill_value
-
-    if parallax is None:
-        parallax = fill_value
-
-    are_arrays = _validate_inputs([ra, dec, pm_ra, pm_dec, v_rad, parallax],
-                                  ['ra', 'dec', 'pm_ra', 'pm_dec', 'v_rad',
-                                   'parallax'],
-                                  "appGeoFromICRS")
 
     # Define star independent mean to apparent place parameters
     # palpy.mappa calculates the star-independent parameters
@@ -516,16 +526,23 @@ def _appGeoFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None,
     # The accuracy is sub-milliarcsecond, limited by the
     # precession-nutation model (see palPrenut for details).
 
-    # because PAL and ERFA expect proper motion in terms of "coordinate
-    # angle; not true angle" (as stated in erfa/starpm.c documentation)
-    pm_ra_corrected = pm_ra / np.cos(dec)
+    if include_px:
+        # because PAL and ERFA expect proper motion in terms of "coordinate
+        # angle; not true angle" (as stated in erfa/starpm.c documentation)
+        pm_ra_corrected = pm_ra / np.cos(dec)
 
     if are_arrays:
-        raOut, decOut = palpy.mapqkVector(ra, dec, pm_ra_corrected, pm_dec,
-                                          arcsecFromRadians(parallax), v_rad, prms)
+        if include_px:
+            raOut, decOut = palpy.mapqkVector(ra, dec, pm_ra_corrected, pm_dec,
+                                              arcsecFromRadians(parallax), v_rad, prms)
+        else:
+            raOut, decOut = palpy.mapqkzVector(ra, dec, prms)
     else:
-        raOut, decOut = palpy.mapqk(ra, dec, pm_ra_corrected, pm_dec,
-                                    arcsecFromRadians(parallax), v_rad, prms)
+        if include_px:
+            raOut, decOut = palpy.mapqk(ra, dec, pm_ra_corrected, pm_dec,
+                                        arcsecFromRadians(parallax), v_rad, prms)
+        else:
+            raOut, decOut = palpy.mapqkz(ra, dec, prms)
 
     return np.array([raOut, decOut])
 
@@ -1005,25 +1022,6 @@ def _observedFromICRS(ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=Non
     RA and the second row is the observed Dec (both in radians)
 
     """
-
-    if isinstance(ra, np.ndarray):
-        fill_value = np.zeros(len(ra))
-    else:
-        fill_value = 0.0
-
-    if pm_ra is None:
-        pm_ra = fill_value
-    if pm_dec is None:
-        pm_dec = fill_value
-    if parallax is None:
-        parallax = fill_value
-    if v_rad is None:
-        v_rad = fill_value
-
-    _validate_inputs([ra, dec, pm_ra, pm_dec, parallax, v_rad],
-                     ['ra', 'dec', 'pm_ra', 'pm_dec', 'parallax',
-                      'v_rad'],
-                     "observedFromICRS")
 
     if obs_metadata is None:
         raise RuntimeError("Cannot call observedFromICRS; obs_metadata is none")

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -542,6 +542,12 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd=None):
     so that the user knows how to query a database of mean RA and Decs
     for objects observed at a given telescope pointing.
 
+    WARNING: This method does not account for apparent motion due to parallax.
+    This means it should not be used to invert the ICRS-to-apparent geocentric
+    transformation for actual celestial objects.  This method is only useful
+    for mapping positions on a theoretical focal plan to positions on the
+    celestial sphere.
+
     This method works in radians.
 
     @param [in] ra in radians (apparent geocentric).  Can be a numpy array or a number.
@@ -591,6 +597,12 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd=None):
     presumably include the above effects) back to mean ICRS RA and Dec
     so that the user knows how to query a database of mean RA and Decs
     for objects observed at a given telescope pointing.
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This means it should not be used to invert the ICRS-to-apparent geocentric
+    transformation for actual celestial objects.  This method is only useful
+    for mapping positions on a theoretical focal plan to positions on the
+    celestial sphere.
 
     This method works in degrees.
 
@@ -1044,6 +1056,12 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
     Note: This method is only accurate at angular distances from the sun of greater
     than 45 degrees and zenith distances of less than 75 degrees.
 
+    WARNING: This method does not account for apparent motion due to parallax.
+    This means it should not be used to invert the ICRS-to-observed coordinates
+    transformation for actual celestial objects.  This method is only useful
+    for mapping positions on a theoretical focal plan to positions on the
+    celestial sphere.
+
     This method works in degrees.
 
     @param [in] ra is the observed RA in degrees.  Can be a numpy array or a number.
@@ -1080,6 +1098,12 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
 
     Note: This method is only accurate at angular distances from the sun of greater
     than 45 degrees and zenith distances of less than 75 degrees.
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This means it should not be used to invert the ICRS-to-observed coordinates
+    transformation for actual celestial objects.  This method is only useful
+    for mapping positions on a theoretical focal plan to positions on the
+    celestial sphere.
 
     This method works in radians.
 

--- a/python/lsst/sims/utils/AstrometryUtils.py
+++ b/python/lsst/sims/utils/AstrometryUtils.py
@@ -562,8 +562,7 @@ def _icrsFromAppGeo(ra, dec, epoch=2000.0, mjd=None):
     WARNING: This method does not account for apparent motion due to parallax.
     This means it should not be used to invert the ICRS-to-apparent geocentric
     transformation for actual celestial objects.  This method is only useful
-    for mapping positions on a theoretical focal plan to positions on the
-    celestial sphere.
+    for mapping positions on a theoretical celestial sphere.
 
     This method works in radians.
 
@@ -618,8 +617,7 @@ def icrsFromAppGeo(ra, dec, epoch=2000.0, mjd=None):
     WARNING: This method does not account for apparent motion due to parallax.
     This means it should not be used to invert the ICRS-to-apparent geocentric
     transformation for actual celestial objects.  This method is only useful
-    for mapping positions on a theoretical focal plan to positions on the
-    celestial sphere.
+    for mapping positions on a theoretical celestial sphere.
 
     This method works in degrees.
 
@@ -1057,8 +1055,7 @@ def icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=T
     WARNING: This method does not account for apparent motion due to parallax.
     This means it should not be used to invert the ICRS-to-observed coordinates
     transformation for actual celestial objects.  This method is only useful
-    for mapping positions on a theoretical focal plan to positions on the
-    celestial sphere.
+    for mapping positions on a theoretical celestial sphere.
 
     This method works in degrees.
 
@@ -1100,8 +1097,7 @@ def _icrsFromObserved(ra, dec, obs_metadata=None, epoch=None, includeRefraction=
     WARNING: This method does not account for apparent motion due to parallax.
     This means it should not be used to invert the ICRS-to-observed coordinates
     transformation for actual celestial objects.  This method is only useful
-    for mapping positions on a theoretical focal plan to positions on the
-    celestial sphere.
+    for mapping positions on a theoretical celestial sphere.
 
     This method works in radians.
 

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -47,6 +47,9 @@ def _validate_inputs(input_list, input_names, method_name):
         msg += "passed to %s " % method_name
         msg += "need to be either numbers or numpy arrays\n"
         msg += "and the same type as the argument %s" % input_names[0]
+        msg += "\n\nTypes of arguments are:\n"
+        for name, arg in zip(input_names, input_list):
+            msg += '%s: %s\n' % (name, type(arg))
         raise RuntimeError(msg)
 
     if desired_type is np.ndarray:

--- a/python/lsst/sims/utils/CompoundCoordinateTransformations.py
+++ b/python/lsst/sims/utils/CompoundCoordinateTransformations.py
@@ -39,6 +39,10 @@ def altAzPaFromRaDec(ra, dec, obs, includeRefraction=True):
     @param [out] azimuth in degrees
 
     @param [out] parallactic angle in degrees
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical celestial
+    sphere.
     """
 
     alt, az, pa = _altAzPaFromRaDec(np.radians(ra), np.radians(dec),
@@ -69,6 +73,10 @@ def _altAzPaFromRaDec(raRad, decRad, obs, includeRefraction=True):
     @param [out] azimuth in radians
 
     @param [out] parallactic angle in radians
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical focal plan
+    to positions on the celestial sphere.
     """
 
     are_arrays = _validate_inputs([raRad, decRad], ['ra', 'dec'],

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -8,12 +8,14 @@ import numpy as np
 import numbers
 import palpy
 
+from lsst.sims.utils.CodeUtilities import _validate_inputs
+
 __all__ = ["_galacticFromEquatorial", "galacticFromEquatorial",
            "_equatorialFromGalactic", "equatorialFromGalactic",
            "sphericalFromCartesian", "cartesianFromSpherical",
            "rotationMatrixFromVectors",
            "equationOfEquinoxes", "calcGmstGast", "calcLmstLast",
-           "haversine",
+           "angularSeparation", "_angularSeparation", "haversine",
            "arcsecFromRadians", "radiansFromArcsec",
            "arcsecFromDegrees", "degreesFromArcsec"]
 
@@ -305,8 +307,93 @@ def calcGmstGast(mjd):
     return gmst, gast
 
 
+def _angularSeparation(long1, lat1, long2, lat2):
+    """
+    Angular separation between two points in radians
+    (just calls palpy.dsep)
+
+    Parameters
+    ----------
+    long1 is the first longitudinal coordinate in radians
+
+    lat1 is the first latitudinal coordinate in radians
+
+    long2 is the second longitudinal coordinate in radians
+
+    lat2 is the second latitudinal coordinate in radians
+
+    Returns
+    -------
+    The angular separation between the two points in radians
+    """
+    are_arrays_1 = _validate_inputs([long1, lat1],
+                                    ['long1', 'lat1'],
+                                    'angularSeparation')
+
+    are_arrays_2 = _validate_inputs([long2, lat2],
+                                    ['long2', 'lat2'],
+                                    'angularSeparation')
+
+    # The code below is necessary because the call to np.radians() in
+    # angularSeparation() will automatically convert floats
+    # into length 1 numpy arrays, confusing validate_inputs()
+    if are_arrays_1 and len(long1) == 1:
+        are_arrays_1 = False
+        long1 = long1[0]
+        lat1 = lat1[0]
+
+    if are_arrays_2 and len(long2) == 1:
+        are_arrays_2 = False
+        long2 = long2[0]
+        lat2 = lat2[0]
+
+    if are_arrays_1 and are_arrays_2:
+        if len(long1) != len(long2):
+            raise RuntimeError("You need to pass arrays of the same length "
+                               "as arguments to angularSeparation()")
+
+        return palpy.dsepVector(long1, lat1, long2, lat2)
+    elif are_arrays_1 and not are_arrays_2:
+        return palpy.dsepVector(long1, lat1,
+                                np.array([long2]*len(long1)),
+                                np.array([lat2]*len(long1)))
+    elif are_arrays_2 and not are_arrays_1:
+        return palpy.dsepVector(np.array([long1]*len(long2)),
+                                np.array([lat1]*len(long2)),
+                                long2, lat2)
+
+    return palpy.dsep(long1, lat1, long2, lat2)
+
+
+def angularSeparation(long1, lat1, long2, lat2):
+    """
+    Angular separation between two points in degrees
+    (just calls palpy.dsep)
+
+    Parameters
+    ----------
+    long1 is the first longitudinal coordinate in degrees
+
+    lat1 is the first latitudinal coordinate in degrees
+
+    long2 is the second longitudinal coordinate in degrees
+
+    lat2 is the second latitudinal coordinate in degrees
+
+    Returns
+    -------
+    The angular separation between the two points in degrees
+    """
+    return np.degrees(_angularSeparation(np.radians(long1),
+                                         np.radians(lat1),
+                                         np.radians(long2),
+                                         np.radians(lat2)))
+
+
 def haversine(long1, lat1, long2, lat2):
     """
+    DEPRECATED; use angularSeparation() instead
+
     Return the angular distance between two points in radians
 
     @param [in] long1 is the longitude of point 1 in radians
@@ -319,11 +406,9 @@ def haversine(long1, lat1, long2, lat2):
 
     @param [out] the angular separation between points 1 and 2 in radians
 
-    From http://en.wikipedia.org/wiki/Haversine_formula
+    Ultimately just calls palpy.dsep
     """
-    t1 = np.sin(lat2 / 2.0 - lat1 / 2.0)**2
-    t2 = np.cos(lat1) * np.cos(lat2) * np.sin(long2 / 2.0 - long1 / 2.0)**2
-    return 2 * np.arcsin(np.sqrt(t1 + t2))
+    return _angularSeparation(long1, lat1, long2, lat2)
 
 
 def arcsecFromRadians(value):

--- a/python/lsst/sims/utils/CoordinateTransformations.py
+++ b/python/lsst/sims/utils/CoordinateTransformations.py
@@ -310,7 +310,6 @@ def calcGmstGast(mjd):
 def _angularSeparation(long1, lat1, long2, lat2):
     """
     Angular separation between two points in radians
-    (just calls palpy.dsep)
 
     Parameters
     ----------
@@ -325,6 +324,9 @@ def _angularSeparation(long1, lat1, long2, lat2):
     Returns
     -------
     The angular separation between the two points in radians
+
+    Calculated based on the haversine formula
+    From http://en.wikipedia.org/wiki/Haversine_formula
     """
     are_arrays_1 = _validate_inputs([long1, lat1],
                                     ['long1', 'lat1'],
@@ -352,23 +354,21 @@ def _angularSeparation(long1, lat1, long2, lat2):
             raise RuntimeError("You need to pass arrays of the same length "
                                "as arguments to angularSeparation()")
 
-        return palpy.dsepVector(long1, lat1, long2, lat2)
-    elif are_arrays_1 and not are_arrays_2:
-        return palpy.dsepVector(long1, lat1,
-                                np.array([long2]*len(long1)),
-                                np.array([lat2]*len(long1)))
-    elif are_arrays_2 and not are_arrays_1:
-        return palpy.dsepVector(np.array([long1]*len(long2)),
-                                np.array([lat1]*len(long2)),
-                                long2, lat2)
+    t1 = np.sin(lat2/2.0 - lat1/2.0)**2
+    t2 = np.cos(lat1)*np.cos(lat2)*np.sin(long2/2.0 - long1/2.0)**2
+    _sum = t1 + t2
 
-    return palpy.dsep(long1, lat1, long2, lat2)
+    if isinstance(_sum, numbers.Number):
+        if _sum<0.0:
+            _sum = 0.0
+    else:
+        _sum = np.where(_sum<0.0, 0.0, _sum)
 
+    return 2.0*np.arcsin(np.sqrt(_sum))
 
 def angularSeparation(long1, lat1, long2, lat2):
     """
     Angular separation between two points in degrees
-    (just calls palpy.dsep)
 
     Parameters
     ----------
@@ -405,8 +405,6 @@ def haversine(long1, lat1, long2, lat2):
     @param [in] lat2 is the latitude of point 2 in radians
 
     @param [out] the angular separation between points 1 and 2 in radians
-
-    Ultimately just calls palpy.dsep
     """
     return _angularSeparation(long1, lat1, long2, lat2)
 

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -253,7 +253,7 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     row is Dec (both in degrees; both in the International Celestial Reference System)
 
     WARNING: This method does not account for apparent motion due to parallax.
-    This method is only useful for mapping positions on a theoretical focal plan
+    This method is only useful for mapping positions on a theoretical focal plane
     to positions on the celestial sphere.
     """
 
@@ -282,7 +282,7 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
     row is Dec (both in radians; both in the International Celestial Reference System)
 
     WARNING: This method does not account for apparent motion due to parallax.
-    This method is only useful for mapping positions on a theoretical focal plan
+    This method is only useful for mapping positions on a theoretical focal plane
     to positions on the celestial sphere.
     """
 

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -251,6 +251,10 @@ def raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
 
     @param [out] a 2-D numpy array in which the first row is RA and the second
     row is Dec (both in degrees; both in the International Celestial Reference System)
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical focal plan
+    to positions on the celestial sphere.
     """
 
     output = _raDecFromPupilCoords(xPupil, yPupil,
@@ -276,6 +280,10 @@ def _raDecFromPupilCoords(xPupil, yPupil, obs_metadata=None, epoch=2000.0):
 
     @param [out] a 2-D numpy array in which the first row is RA and the second
     row is Dec (both in radians; both in the International Celestial Reference System)
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical focal plan
+    to positions on the celestial sphere.
     """
 
     are_arrays = _validate_inputs([xPupil, yPupil], ['xPupil', 'yPupil'], "raDecFromPupilCoords")

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -5,7 +5,8 @@ from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.sims.utils import _observedFromICRS, _icrsFromObserved
 from lsst.sims.utils import radiansFromArcsec
 
-__all__ = ["_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
+__all__ = ["_pupilCoordsFromObserved",
+           "_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
            "_raDecFromPupilCoords", "raDecFromPupilCoords"]
 
 
@@ -145,14 +146,43 @@ def _pupilCoordsFromRaDec(ra_in, dec_in,
     if obs_metadata.pointingRA is None or obs_metadata.pointingDec is None:
         raise RuntimeError("Cannot calculate [x,y]_focal_nominal without pointingRA and Dec in obs_metadata")
 
-    theta = obs_metadata._rotSkyPos
-
     ra_obs, dec_obs = _observedFromICRS(ra_in, dec_in,
                                         pm_ra=pm_ra, pm_dec=pm_dec,
                                         parallax=parallax, v_rad=v_rad,
                                         obs_metadata=obs_metadata,
                                         epoch=epoch,
                                         includeRefraction=includeRefraction)
+
+    return _pupilCoordsFromObserved(ra_obs, dec_obs, obs_metadata,
+                                    epoch=epoch, includeRefraction=includeRefraction)
+
+
+def _pupilCoordsFromObserved(ra_obs, dec_obs, obs_metadata, epoch=2000.0, includeRefraction=True):
+    """
+    Convert Observed RA, Dec into pupil coordinates
+
+    Parameters
+    ----------
+    ra_obs is the observed RA in radians
+
+    dec_obs is the observed Dec in radians
+
+    obs_metadata is an ObservationMetaData characterizing the telescope location and pointing
+
+    epoch is the epoch of the mean RA and Dec in julian years (default=2000.0)
+
+    includeRefraction is a boolean controlling the application of refraction.
+
+    Returns
+    --------
+    A numpy array whose first row is the x coordinate on the pupil in
+    radians and whose second row is the y coordinate in radians
+    """
+
+    are_arrays = _validate_inputs([ra_obs, dec_obs], ['ra_obs', 'dec_obs'],
+                                  "pupilCoordsFromObserved")
+
+    theta = obs_metadata._rotSkyPos
 
     ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
                                                   obs_metadata._pointingDec,

--- a/python/lsst/sims/utils/FocalPlaneUtils.py
+++ b/python/lsst/sims/utils/FocalPlaneUtils.py
@@ -3,12 +3,16 @@ import numpy as np
 import palpy
 from lsst.sims.utils.CodeUtilities import _validate_inputs
 from lsst.sims.utils import _observedFromICRS, _icrsFromObserved
+from lsst.sims.utils import radiansFromArcsec
 
 __all__ = ["_pupilCoordsFromRaDec", "pupilCoordsFromRaDec",
            "_raDecFromPupilCoords", "raDecFromPupilCoords"]
 
 
-def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
+def pupilCoordsFromRaDec(ra_in, dec_in,
+                         pm_ra=None, pm_dec=None, parallax=None,
+                         v_rad=None, includeRefraction=True,
+                         obs_metadata=None, epoch=2000.0):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -29,6 +33,20 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
 
     @param [in] dec_in is in degrees (ICRS).  Can be either a numpy array or a number.
 
+    @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] pm_dec is proper motion in dec (arcsec/yr)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] parallax is parallax in arcsec
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] v_rad is radial velocity (km/s)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] includeRefraction is a boolean controlling the application of refraction.
+
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
 
@@ -38,11 +56,33 @@ def pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     radians and whose second row is the y coordinate in radians
     """
 
+    if pm_ra is not None:
+        pm_ra_in = radiansFromArcsec(pm_ra)
+    else:
+        pm_ra_in = None
+
+    if pm_dec is not None:
+        pm_dec_in = radiansFromArcsec(pm_dec)
+    else:
+        pm_dec_in = None
+
+    if parallax is not None:
+        parallax_in = radiansFromArcsec(parallax)
+    else:
+        parallax_in = None
+
     return _pupilCoordsFromRaDec(np.radians(ra_in), np.radians(dec_in),
+                                 pm_ra=pm_ra_in, pm_dec=pm_dec_in,
+                                 parallax=parallax_in, v_rad=v_rad,
+                                 includeRefraction=includeRefraction,
                                  obs_metadata=obs_metadata, epoch=epoch)
 
 
-def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
+def _pupilCoordsFromRaDec(ra_in, dec_in,
+                          pm_ra=None, pm_dec=None,
+                          parallax=None, v_rad=None,
+                          includeRefraction=True,
+                          obs_metadata=None, epoch=2000.0):
     """
     Take an input RA and dec from the sky and convert it to coordinates
     on the focal plane.
@@ -62,6 +102,20 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
     @param [in] ra_in is in radians (ICRS).  Can be either a numpy array or a number.
 
     @param [in] dec_in is in radians (ICRS).  Can be either a numpy array or a number.
+
+    @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] pm_dec is proper motion in dec (radians/yr)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] parallax is parallax in radians
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] v_rad is radial velocity (km/s)
+    Can be a numpy array or a number or None (default=None).
+
+    @param [in] includeRefraction is a boolean controlling the application of refraction.
 
     @param [in] obs_metadata is an ObservationMetaData instantiation characterizing the
     telescope location and pointing.
@@ -93,13 +147,18 @@ def _pupilCoordsFromRaDec(ra_in, dec_in, obs_metadata=None, epoch=2000.0):
 
     theta = obs_metadata._rotSkyPos
 
-    ra_obs, dec_obs = _observedFromICRS(ra_in, dec_in, obs_metadata=obs_metadata,
-                                        epoch=epoch, includeRefraction=True)
+    ra_obs, dec_obs = _observedFromICRS(ra_in, dec_in,
+                                        pm_ra=pm_ra, pm_dec=pm_dec,
+                                        parallax=parallax, v_rad=v_rad,
+                                        obs_metadata=obs_metadata,
+                                        epoch=epoch,
+                                        includeRefraction=includeRefraction)
 
     ra_pointing, dec_pointing = _observedFromICRS(obs_metadata._pointingRA,
                                                   obs_metadata._pointingDec,
                                                   obs_metadata=obs_metadata,
-                                                  epoch=epoch, includeRefraction=True)
+                                                  epoch=epoch,
+                                                  includeRefraction=includeRefraction)
 
     # palpy.ds2tp performs the gnomonic projection on ra_in and dec_in
     # with a tangent point at (pointingRA, pointingDec)

--- a/python/lsst/sims/utils/WcsUtils.py
+++ b/python/lsst/sims/utils/WcsUtils.py
@@ -182,6 +182,10 @@ def _nativeLonLatFromRaDec(ra_in, dec_in, obs_metadata):
     System.  Before calculating native longitude and latitude, this method will
     convert RA and Dec to observed geocentric coordinates.
 
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical
+    celestial sphere.
+
     @param [in] ra is the RA of the star being transformed in radians
     (in the International Celestial Reference System)
 
@@ -225,6 +229,10 @@ def nativeLonLatFromRaDec(ra, dec, obs_metadata):
     Note: RA, and Dec are assumed to be in the International Celestial Reference
     System.  Before calculating native longitude and latitude, this method will
     convert RA and Dec to observed geocentric coordinates.
+
+    WARNING: This method does not account for apparent motion due to parallax.
+    This method is only useful for mapping positions on a theoretical
+    celestial sphere.
 
     @param [in] ra is the RA of the star being transformed in degrees
     (in the International Celestial Reference System)

--- a/tests/testCompoundCoordinateTransformations.py
+++ b/tests/testCompoundCoordinateTransformations.py
@@ -58,6 +58,8 @@ def controlAltAzFromRaDec(raRad_in, decRad_in, longRad, latRad, mjd):
     altRad = np.arcsin(sinAlt)
     azRad = np.arccos((sinDec - sinAlt*sinLat) / (np.cos(altRad)*cosLat))
     azRadOut = np.where(np.sin(haRad) >= 0.0, 2.0 * np.pi - azRad, azRad)
+    if isinstance(altRad, float):
+        return altRad, float(azRadOut)
     return altRad, azRadOut
 
 

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -1,4 +1,4 @@
-from __future__ import division
+from __future__ import division, with_statement
 from builtins import zip
 from builtins import range
 import numpy as np
@@ -46,6 +46,471 @@ def controlCalcGmstGast(mjd):
     gmst %= 24.
     gast %= 24.
     return gmst, gast
+
+
+class AngularSeparationTestCase(unittest.TestCase):
+
+    def testAngSepExceptions(self):
+        """
+        Test that an exception is raised when you pass
+        mismatched inputs to angularSeparation.
+        """
+        ra1 = 23.0
+        dec1 = -12.0
+        ra2 = 45.0
+        dec2 = 33.1
+        ra1_arr = np.array([11.0, 21.0, 33.1])
+        dec1_arr = np.array([-11.1, 34.1, 86.2])
+        ra2_arr = np.array([45.2, 112.0, 89.3])
+        dec2_arr = np.array([11.1, -45.0, -71.0])
+
+        # test that everything runs
+        utils._angularSeparation(np.radians(ra1), np.radians(dec1),
+                                 np.radians(ra2), np.radians(dec2))
+        utils.angularSeparation(ra1, dec1, ra2, dec2)
+        ans = utils._angularSeparation(np.radians(ra1_arr), np.radians(dec1_arr),
+                                       np.radians(ra2_arr), np.radians(dec2_arr))
+        self.assertEqual(len(ans), 3)
+        ans = utils.angularSeparation(ra1_arr, dec1_arr, ra2_arr, dec2_arr)
+        self.assertEqual(len(ans), 3)
+
+        ans = utils.angularSeparation(ra1_arr, dec1_arr, ra2, dec2)
+        self.assertEqual(len(ans), 3)
+        ans = utils._angularSeparation(ra1_arr, ra2_arr, ra2, dec2)
+        self.assertEqual(len(ans), 3)
+
+        ans = utils.angularSeparation(ra1, dec1, ra2_arr, dec2_arr)
+        self.assertEqual(len(ans), 3)
+        ans = utils._angularSeparation(dec1, ra1, ra2_arr, dec2_arr)
+        self.assertEqual(len(ans), 3)
+
+        # test with lists
+        # Note: these exceptions will not get raised if you call
+        # angularSeparation() with lists instead of numpy arrays
+        # because the conversion from degrees to radians with
+        # np.radians will automatically convert the lists into arrays
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(list(ra1_arr), dec1_arr, ra2_arr, dec2_arr)
+        self.assertIn("number", context.exception.message)
+        self.assertIn("numpy array", context.exception.message)
+        self.assertIn("long1", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, list(dec1_arr), ra2_arr, dec2_arr)
+        self.assertIn("number", context.exception.message)
+        self.assertIn("numpy array", context.exception.message)
+        self.assertIn("lat1", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr, list(ra2_arr), dec2_arr)
+        self.assertIn("number", context.exception.message)
+        self.assertIn("numpy array", context.exception.message)
+        self.assertIn("long2", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr, ra2_arr, list(dec2_arr))
+        self.assertIn("number", context.exception.message)
+        self.assertIn("numpy array", context.exception.message)
+        self.assertIn("lat2", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        # test with numbers and arrays
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1, ra2, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, dec1_arr, ra2, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, dec1, ra2_arr, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, dec1, ra2, dec2_arr)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr, dec1, ra2, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1, dec1_arr, ra2, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1, dec1, ra2_arr, dec2)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1, dec1, ra2, dec2_arr)
+        self.assertIn("the same type", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        # test with mismatched arrays
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr[:2], dec1_arr, ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr[:2], ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr, ra2_arr[:2], dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr, ra2_arr, dec2_arr[:2])
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr[:2], dec1_arr, ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr, dec1_arr[:2], ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr, dec1_arr, ra2_arr[:2], dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr, dec1_arr, ra2_arr, dec2_arr[:2])
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr[:2], dec1_arr[:2], ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1_arr, dec1_arr, ra2_arr[:2], dec2_arr[:2])
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr[:2], dec1_arr[:2], ra2_arr, dec2_arr)
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils.angularSeparation(ra1_arr, dec1_arr, ra2_arr[:2], dec2_arr[:2])
+        self.assertIn("same length", context.exception.message)
+        self.assertIn("angularSeparation", context.exception.message)
+
+        # test that a sensible error is raised if you pass a string
+        # into angularSeparation
+        # Note: a different error will be raised if you pass these
+        # bad inputs into angularSeparation().  The exception will come
+        # from trying to convert a str with np.radians
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation('a', dec1, ra2, dec2)
+        self.assertIn("angularSeparation", context.exception.message)
+        self.assertIn("number", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, 'a', ra2, dec2)
+        self.assertIn("angularSeparation", context.exception.message)
+        self.assertIn("number", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, dec1, 'a', dec2)
+        self.assertIn("angularSeparation", context.exception.message)
+        self.assertIn("number", context.exception.message)
+
+        with self.assertRaises(RuntimeError) as context:
+            utils._angularSeparation(ra1, dec1, ra2, 'a')
+        self.assertIn("angularSeparation", context.exception.message)
+        self.assertIn("number", context.exception.message)
+
+    def testAngSepResultsArr(self):
+        """
+        Test that angularSeparation gives the correct answer by comparing
+        results with the dot products of Cartesian vectors.  Pass in arrays
+        of arguments.
+        """
+        rng = np.random.RandomState(99421)
+        n_obj = 100
+        ra1 = rng.random_sample(n_obj)*2.0*np.pi
+        dec1 = rng.random_sample(n_obj)*np.pi - 0.5*np.pi
+        ra2 = rng.random_sample(n_obj)*2.0*np.pi
+        dec2 = rng.random_sample(n_obj)*np.pi - 0.5*np.pi
+
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+
+        x2 = np.cos(dec2)*np.cos(ra2)
+        y2 = np.cos(dec2)*np.sin(ra2)
+        z2 = np.sin(dec2)
+
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        test = np.cos(test)
+        control = x1*x2 + y1*y2 + z1*z2
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                       np.degrees(ra2), np.degrees(dec2))
+        test = np.cos(np.radians(test))
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        # specifically test at the north pole
+        dec1 = np.ones(n_obj)*np.pi
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+        control = x1*x2 + y1*y2 + z1*z2
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        test = np.cos(test)
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                       np.degrees(ra2), np.degrees(dec2))
+        test = np.cos(np.radians(test))
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        # specifically test at the south pole
+        dec1 = -1.0*np.ones(n_obj)*np.pi
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+        control = x1*x2 + y1*y2 + z1*z2
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        test = np.cos(test)
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                       np.degrees(ra2), np.degrees(dec2))
+        test = np.cos(np.radians(test))
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+    def testAngSepResultsFloat(self):
+        """
+        Test that angularSeparation gives the correct answer by comparing
+        results with the dot products of Cartesian vectors.  Pass in floats
+        as arguments.
+        """
+        rng = np.random.RandomState(831)
+        ra1 = rng.random_sample()*2.0*np.pi
+        dec1 = rng.random_sample()*np.pi-0.5*np.pi
+        ra2 = rng.random_sample()*2.0*np.pi
+        dec2 = rng.random_sample()*np.pi-0.5*np.pi
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+
+        x2 = np.cos(dec2)*np.cos(ra2)
+        y2 = np.cos(dec2)*np.sin(ra2)
+        z2 = np.sin(dec2)
+
+        control = x1*x2 + y1*y2 + z1*z2
+
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils._angularSeparation(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils._angularSeparation(ra1, dec1, np.array([ra2]), np.array([dec2]))
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        # try north pole
+        ra1 = 0.5*np.pi
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+        control = x1*x2 + y1*y2 + z1*z2
+
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils._angularSeparation(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils._angularSeparation(ra1, dec1, np.array([ra2]), np.array([dec2]))
+        self.assertIsInstance(test, float)
+        test = np.cos(test)
+        self.assertAlmostEqual(control, test, 15)
+
+        # do all of that in degrees
+        ra1 = rng.random_sample()*360.0
+        dec1 = rng.random_sample()*180.0-90.0
+        ra2 = rng.random_sample()*360.0
+        dec2 = rng.random_sample()*180.0-90.0
+        x1 = np.cos(np.radians(dec1))*np.cos(np.radians(ra1))
+        y1 = np.cos(np.radians(dec1))*np.sin(np.radians(ra1))
+        z1 = np.sin(np.radians(dec1))
+
+        x2 = np.cos(np.radians(dec2))*np.cos(np.radians(ra2))
+        y2 = np.cos(np.radians(dec2))*np.sin(np.radians(ra2))
+        z2 = np.sin(np.radians(dec2))
+
+        control = x1*x2 + y1*y2 + z1*z2
+
+        test = utils.angularSeparation(ra1, dec1, ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils.angularSeparation(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils.angularSeparation(ra1, dec1, np.array([ra2]), np.array([dec2]))
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+        # try north pole
+        ra1 = 90.0
+        x1 = np.cos(np.radians(dec1))*np.cos(np.radians(ra1))
+        y1 = np.cos(np.radians(dec1))*np.sin(np.radians(ra1))
+        z1 = np.sin(np.radians(dec1))
+        control = x1*x2 + y1*y2 + z1*z2
+
+        test = utils.angularSeparation(ra1, dec1, ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils.angularSeparation(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+        test = utils.angularSeparation(ra1, dec1, np.array([ra2]), np.array([dec2]))
+        self.assertIsInstance(test, float)
+        test = np.cos(np.radians(test))
+        self.assertAlmostEqual(control, test, 15)
+
+    def testAngSepResultsMixed(self):
+        """
+        Test that angularSeparation gives the correct answer by comparing
+        results with the dot products of Cartesian vectors.  Pass in mixtures
+        of floats and arrays as arguments.
+        """
+        rng = np.random.RandomState(8131)
+        n_obj = 100
+        ra1 = rng.random_sample(n_obj)*2.0*np.pi
+        dec1 = rng.random_sample(n_obj)*np.pi - 0.5*np.pi
+        ra2 = rng.random_sample()*2.0*np.pi
+        dec2 = rng.random_sample()*np.pi - 0.5*np.pi
+        self.assertIsInstance(ra1, np.ndarray)
+        self.assertIsInstance(dec1, np.ndarray)
+        self.assertIsInstance(ra2, float)
+        self.assertIsInstance(dec2, float)
+
+        x1 = np.cos(dec1)*np.cos(ra1)
+        y1 = np.cos(dec1)*np.sin(ra1)
+        z1 = np.sin(dec1)
+
+        x2 = np.cos(dec2)*np.cos(ra2)
+        y2 = np.cos(dec2)*np.sin(ra2)
+        z2 = np.sin(dec2)
+
+        control = x1*x2 + y1*y2 + z1*z2
+        test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        test = np.cos(test)
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+        test = utils._angularSeparation(ra2, dec2, ra1, dec1)
+        test = np.cos(test)
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+        # now do it in degrees
+        ra1 = rng.random_sample(n_obj)*360.0
+        dec1 = rng.random_sample(n_obj)*180.0 - 90.0
+        ra2 = rng.random_sample()*360.0
+        dec2 = rng.random_sample()*180.0 - 90.0
+        self.assertIsInstance(ra1, np.ndarray)
+        self.assertIsInstance(dec1, np.ndarray)
+        self.assertIsInstance(ra2, float)
+        self.assertIsInstance(dec2, float)
+
+        x1 = np.cos(np.radians(dec1))*np.cos(np.radians(ra1))
+        y1 = np.cos(np.radians(dec1))*np.sin(np.radians(ra1))
+        z1 = np.sin(np.radians(dec1))
+
+        x2 = np.cos(np.radians(dec2))*np.cos(np.radians(ra2))
+        y2 = np.cos(np.radians(dec2))*np.sin(np.radians(ra2))
+        z2 = np.sin(np.radians(dec2))
+
+        control = x1*x2 + y1*y2 + z1*z2
+        test = utils.angularSeparation(ra1, dec1, ra2, dec2)
+        test = np.cos(np.radians(test))
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+        test = utils.angularSeparation(ra2, dec2, ra1, dec1)
+        test = np.cos(np.radians(test))
+        np.testing.assert_array_almost_equal(test, control, decimal=15)
+
+    def testHaversine(self):
+        """
+        Test that haversine() returns the same thing as _angularSeparation
+        """
+
+        ra1 = 0.2
+        dec1 = 1.3
+        ra2 = 2.1
+        dec2 = -0.5
+        ra3 = np.array([1.9, 2.1, 0.3])
+        dec3 = np.array([-1.1, 0.34, 0.01])
+        control = utils._angularSeparation(ra1, dec1, ra2, dec2)
+        test = utils.haversine(ra1, dec1, ra2, dec2)
+        self.assertIsInstance(test, float)
+        self.assertEqual(test, control)
+
+        control = utils._angularSeparation(ra1, dec1, ra3, dec3)
+        test = utils.haversine(ra1, dec1, ra3, dec3)
+        np.testing.assert_array_equal(test, control)
+
+        control = utils._angularSeparation(np.array([ra1]), np.array([dec1]), ra3, dec3)
+        test = utils.haversine(np.array([ra1]), np.array([dec1]), ra3, dec3)
+        np.testing.assert_array_equal(test, control)
+
+        control = utils._angularSeparation(ra3, dec3, np.array([ra1]), np.array([dec1]))
+        test = utils.haversine(ra3, dec3, np.array([ra1]), np.array([dec1]))
+        np.testing.assert_array_equal(test, control)
+
+        control = utils._angularSeparation(ra2, dec2, np.array([ra1]), np.array([dec1]))
+        test = utils.haversine(ra2, dec2, np.array([ra1]), np.array([dec1]))
+        self.assertIsInstance(test, float)
+        self.assertEqual(test, control)
+
+        control = utils._angularSeparation(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        test = utils.haversine(np.array([ra1]), np.array([dec1]), ra2, dec2)
+        self.assertIsInstance(test, float)
+        self.assertEqual(test, control)
 
 
 class testCoordinateTransformations(unittest.TestCase):

--- a/tests/testCoordinateTransformations.py
+++ b/tests/testCoordinateTransformations.py
@@ -305,6 +305,70 @@ class AngularSeparationTestCase(unittest.TestCase):
         test = np.cos(np.radians(test))
         np.testing.assert_array_almost_equal(test, control, decimal=15)
 
+    def testAngSepResultsExtreme(self):
+        """
+        Test that angularSeparation gives the correct answer by comparing
+        results with the dot products of Cartesian vectors.  Test on extremal
+        values (i.e. longitudes that go beyond 360.0 and latitudes that go
+        beyond 90.0)
+        """
+        rng = np.random.RandomState(99421)
+        n_obj = 100
+        for sgn in (-1.0, 1.0):
+            ra1 = sgn*(rng.random_sample(n_obj)*2.0*np.pi + 2.0*np.pi)
+            dec1 = sgn*(rng.random_sample(n_obj)*4.0*np.pi + 2.0*np.pi)
+            ra2 = sgn*(rng.random_sample(n_obj)*2.0*np.pi + 2.0*np.pi)
+            dec2 = sgn*(rng.random_sample(n_obj)*2.0*np.pi + 2.0*np.pi)
+
+            x1 = np.cos(dec1)*np.cos(ra1)
+            y1 = np.cos(dec1)*np.sin(ra1)
+            z1 = np.sin(dec1)
+
+            x2 = np.cos(dec2)*np.cos(ra2)
+            y2 = np.cos(dec2)*np.sin(ra2)
+            z2 = np.sin(dec2)
+
+            test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+            test = np.cos(test)
+            control = x1*x2 + y1*y2 + z1*z2
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
+            test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                           np.degrees(ra2), np.degrees(dec2))
+            test = np.cos(np.radians(test))
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
+            # specifically test at the north pole
+            dec1 = np.ones(n_obj)*np.pi
+            x1 = np.cos(dec1)*np.cos(ra1)
+            y1 = np.cos(dec1)*np.sin(ra1)
+            z1 = np.sin(dec1)
+            control = x1*x2 + y1*y2 + z1*z2
+            test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+            test = np.cos(test)
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
+            test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                           np.degrees(ra2), np.degrees(dec2))
+            test = np.cos(np.radians(test))
+            dd = np.abs(test-control)
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
+            # specifically test at the south pole
+            dec1 = -1.0*np.ones(n_obj)*np.pi
+            x1 = np.cos(dec1)*np.cos(ra1)
+            y1 = np.cos(dec1)*np.sin(ra1)
+            z1 = np.sin(dec1)
+            control = x1*x2 + y1*y2 + z1*z2
+            test = utils._angularSeparation(ra1, dec1, ra2, dec2)
+            test = np.cos(test)
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
+            test = utils.angularSeparation(np.degrees(ra1), np.degrees(dec1),
+                                           np.degrees(ra2), np.degrees(dec2))
+            test = np.cos(np.radians(test))
+            np.testing.assert_array_almost_equal(test, control, decimal=14)
+
     def testAngSepResultsFloat(self):
         """
         Test that angularSeparation gives the correct answer by comparing

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -318,6 +318,26 @@ class PupilCoordinateUnitTest(unittest.TestCase):
             np.testing.assert_array_equal(xp_rad, xp_test)
             np.testing.assert_array_equal(yp_rad, yp_test)
 
+            # now test it with proper motion = 0
+            ra_obs, dec_obs = observedFromICRS(ra_list, dec_list,
+                                               parallax=px_list, v_rad=v_rad_list,
+                                               obs_metadata=obs, epoch=2000.0,
+                                               includeRefraction=includeRefraction)
+
+            ra_icrs, dec_icrs = icrsFromObserved(ra_obs, dec_obs, obs_metadata=obs,
+                                                 epoch=2000.0, includeRefraction=includeRefraction)
+
+            xp_control, yp_control = pupilCoordsFromRaDec(ra_icrs, dec_icrs, obs_metadata=obs,
+                                                          epoch=2000.0, includeRefraction=includeRefraction)
+
+            xp_test, yp_test = pupilCoordsFromRaDec(ra_list, dec_list,
+                                                    parallax=px_list, v_rad=v_rad_list,
+                                                    obs_metadata=obs, epoch=2000.0,
+                                                    includeRefraction=includeRefraction)
+
+            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control,2) + np.power(yp_test-yp_control,2)))
+            self.assertLess(distance.max(), 0.006)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -306,6 +306,18 @@ class PupilCoordinateUnitTest(unittest.TestCase):
             distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control,2) + np.power(yp_test-yp_control,2)))
             self.assertLess(distance.max(), 0.006)
 
+            # now test it in radians
+            xp_rad, yp_rad = _pupilCoordsFromRaDec(np.radians(ra_list), np.radians(dec_list),
+                                                   pm_ra=radiansFromArcsec(pm_ra_list),
+                                                   pm_dec=radiansFromArcsec(pm_dec_list),
+                                                   parallax=radiansFromArcsec(px_list),
+                                                   v_rad=v_rad_list,
+                                                   obs_metadata=obs, epoch=2000.0,
+                                                   includeRefraction=includeRefraction)
+
+            np.testing.assert_array_equal(xp_rad, xp_test)
+            np.testing.assert_array_equal(yp_rad, yp_test)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -268,7 +268,7 @@ class PupilCoordinateUnitTest(unittest.TestCase):
             obs = ObservationMetaData(mjd=mjd_tai)
             ra, dec = raDecFromAltAz(78.0, 112.0, obs)
             dd = distanceToSun(ra, dec, obs.mjd)
-            if dd>45.0:
+            if dd > 45.0:
                 is_valid = True
 
         n_obj = 1000
@@ -303,7 +303,8 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                                     obs_metadata=obs, epoch=2000.0,
                                                     includeRefraction=includeRefraction)
 
-            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control,2) + np.power(yp_test-yp_control,2)))
+            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control, 2) +
+                                                 np.power(yp_test-yp_control, 2)))
             self.assertLess(distance.max(), 0.006)
 
             # now test it in radians
@@ -335,7 +336,8 @@ class PupilCoordinateUnitTest(unittest.TestCase):
                                                     obs_metadata=obs, epoch=2000.0,
                                                     includeRefraction=includeRefraction)
 
-            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control,2) + np.power(yp_test-yp_control,2)))
+            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control, 2) +
+                                                 np.power(yp_test-yp_control, 2)))
             self.assertLess(distance.max(), 0.006)
 
 

--- a/tests/testPupilCoordinates.py
+++ b/tests/testPupilCoordinates.py
@@ -6,10 +6,12 @@ import unittest
 import lsst.utils.tests
 
 from lsst.sims.utils import ObservationMetaData, _nativeLonLatFromRaDec
-from lsst.sims.utils import _pupilCoordsFromRaDec
+from lsst.sims.utils import _pupilCoordsFromRaDec, pupilCoordsFromRaDec
 from lsst.sims.utils import _raDecFromPupilCoords
 from lsst.sims.utils import _observedFromICRS, _icrsFromObserved
 from lsst.sims.utils import haversine, arcsecFromRadians, solarRaDec, ModifiedJulianDate, distanceToSun
+from lsst.sims.utils import raDecFromAltAz, observedFromICRS, icrsFromObserved
+from lsst.sims.utils import radiansFromArcsec
 
 
 def setup_module(module):
@@ -250,6 +252,59 @@ class PupilCoordinateUnitTest(unittest.TestCase):
             else:
                 np.testing.assert_equal(xt, np.NaN)
                 np.testing.assert_equal(yt, np.NaN)
+
+    def test_with_proper_motion(self):
+        """
+        Test that calculating pupil coordinates in the presence of proper motion, parallax,
+        and radial velocity is equivalent to
+        observedFromICRS -> icrsFromObserved -> pupilCoordsFromRaDec
+        (mostly to make surethat pupilCoordsFromRaDec is correctly calling observedFromICRS
+        with non-zero proper motion, etc.)
+        """
+        rng = np.random.RandomState(38442)
+        is_valid = False
+        while not is_valid:
+            mjd_tai = 59580.0 + 10000.0*rng.random_sample()
+            obs = ObservationMetaData(mjd=mjd_tai)
+            ra, dec = raDecFromAltAz(78.0, 112.0, obs)
+            dd = distanceToSun(ra, dec, obs.mjd)
+            if dd>45.0:
+                is_valid = True
+
+        n_obj = 1000
+        rr = rng.random_sample(n_obj)*2.0
+        theta = rng.random_sample(n_obj)*2.0*np.pi
+        ra_list = ra + rr*np.cos(theta)
+        dec_list = dec + rr*np.sin(theta)
+        obs = ObservationMetaData(pointingRA=ra, pointingDec=dec, mjd=mjd_tai, rotSkyPos=19.0)
+
+        pm_ra_list = rng.random_sample(n_obj)*100.0 - 50.0
+        pm_dec_list = rng.random_sample(n_obj)*100.0 - 50.0
+        px_list = rng.random_sample(n_obj) + 0.05
+        v_rad_list = rng.random_sample(n_obj)*600.0 - 300.0
+
+        for includeRefraction in (True, False):
+
+            ra_obs, dec_obs = observedFromICRS(ra_list, dec_list,
+                                               pm_ra=pm_ra_list, pm_dec=pm_dec_list,
+                                               parallax=px_list, v_rad=v_rad_list,
+                                               obs_metadata=obs, epoch=2000.0,
+                                               includeRefraction=includeRefraction)
+
+            ra_icrs, dec_icrs = icrsFromObserved(ra_obs, dec_obs, obs_metadata=obs,
+                                                 epoch=2000.0, includeRefraction=includeRefraction)
+
+            xp_control, yp_control = pupilCoordsFromRaDec(ra_icrs, dec_icrs, obs_metadata=obs,
+                                                          epoch=2000.0, includeRefraction=includeRefraction)
+
+            xp_test, yp_test = pupilCoordsFromRaDec(ra_list, dec_list,
+                                                    pm_ra=pm_ra_list, pm_dec=pm_dec_list,
+                                                    parallax=px_list, v_rad=v_rad_list,
+                                                    obs_metadata=obs, epoch=2000.0,
+                                                    includeRefraction=includeRefraction)
+
+            distance = arcsecFromRadians(np.sqrt(np.power(xp_test-xp_control,2) + np.power(yp_test-yp_control,2)))
+            self.assertLess(distance.max(), 0.006)
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
While playing around with some of our astrometry transformations, I noticed that icrsFromObserved did not exactly invert observedFromICRS.  Parallax was not being treated properly in icrsFromObserved.  After corresponding with the authors of PAL, I discovered that this was because the PAL routines underlying icrsFromObserved were never actually meant to invert the transformation from ICRS to geocentric apparent position in such a way as to include a proper treatment of parallax (in their minds, if you knew parallax, you must already know the ICRS position).  This doesn't really pose a problem for us, as we don't need icrsFromObserved for anything (except, maybe, inverting the weird transformation from RA, Dec to whatever coordinates PhoSim expects).  It did, however, cause me to realize that some of our other coordinate transformation methods were not correctly treating parallax and proper motion.  This pull request updates those coordinate transformation.  It also adds warnings to the docstrings of methods which cannot treat parallax correctly (mostly inversion methods along the lines of icrsFromObserved).  This is a basic enough update that it created ripples.  There are also pull requests in

sims_coordUtils
sims_catUtils
sims_GalSimInterface

Note: one of the new unit tests in sims_utils is marked as an expectedFailure.  That is waiting on this pull request in PAL

https://github.com/Starlink/pal/pull/11