### PR TITLE
Feature/sim 2112/write end2end scripts

### DIFF
--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -23,13 +23,10 @@ def sims_clean_up():
     for target in sims_clean_up.targets:
         if isinstance(target,dict):
             while len(target) > 0:
-                keys = list(target.keys())
-                target.pop(keys[0])
-            target = {}
+                target.popitem()
         elif isinstance(target, list):
             while len(target) > 0:
                 target.pop()
-            target = []
 
     return None
 

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -2,6 +2,38 @@ from builtins import zip
 import numpy as np
 import numbers
 
+def sims_clean_up():
+    """
+    This method will clean up data caches created by the sims software stack.
+    Any time a cache is added to the sims software stack, it can be added to
+    the list sims_clean_up.targets.  When sims_clean_up() is called, it will
+    loop through the contents of sims_clean_up.targets.  It will call pop()
+    on all of the contents of each sims_clean_up.target, and then reset each
+    sims_clean_up.target to either a blank dict or list (depending on what
+    the target was).
+
+    Note: this method assumes that all relevant caches are either dicts
+    or lists.  If it encounters another object, sims_clean_up() will do
+    nothing.
+    """
+
+    if not hasattr(sims_clean_up, 'targets'):
+        return None
+
+    for target in sims_clean_up.targets:
+        if isinstance(target,dict):
+            while len(target) > 0:
+                keys = list(target.keys())
+                target.pop(keys[0])
+            target = {}
+        elif isinstance(target, list):
+            while len(target) > 0:
+                target.pop()
+            target = []
+
+    return None
+
+sims_clean_up.targets = []
 
 def _validate_inputs(input_list, input_names, method_name):
     """

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -2,6 +2,7 @@ from builtins import zip
 import numpy as np
 import numbers
 
+
 def sims_clean_up():
     """
     This method will clean up data caches created by the sims software stack.
@@ -21,7 +22,7 @@ def sims_clean_up():
         return None
 
     for target in sims_clean_up.targets:
-        if isinstance(target,dict):
+        if isinstance(target, dict):
             while len(target) > 0:
                 target.popitem()
         elif isinstance(target, list):
@@ -31,6 +32,7 @@ def sims_clean_up():
     return None
 
 sims_clean_up.targets = []
+
 
 def _validate_inputs(input_list, input_names, method_name):
     """

--- a/python/lsst/sims/utils/ModifiedJulianDate.py
+++ b/python/lsst/sims/utils/ModifiedJulianDate.py
@@ -160,6 +160,9 @@ class ModifiedJulianDate(object):
     def __eq__(self, other):
         return self._time == other._time
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __deepcopy__(self, memo):
         if self._initialized_with == 'TAI':
             new_mjd = ModifiedJulianDate(TAI=self.TAI)

--- a/python/lsst/sims/utils/ObservationMetaData.py
+++ b/python/lsst/sims/utils/ObservationMetaData.py
@@ -173,6 +173,46 @@ class ObservationMetaData(object):
 
         return mydict
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __eq__(self, other):
+
+        if self.bounds != other.bounds:
+            return False
+
+        if self.pointingRA != other.pointingRA:
+            return False
+
+        if self.pointingDec != other.pointingDec:
+            return False
+
+        if self.rotSkyPos != other.rotSkyPos:
+            return False
+
+        if self.bandpass != other.bandpass:
+            return False
+
+        if self.seeing != other.seeing:
+            return False
+
+        if self.m5 != other.m5:
+            return False
+
+        if self.site != other.site:
+            return False
+
+        if self.mjd != other.mjd:
+            return False
+
+        if self.skyBrightness != other.skyBrightness:
+            return False
+
+        if self.OpsimMetaData != other.OpsimMetaData:
+            return False
+
+        return True
+
     def _assignDictKeyedToBandpass(self, inputValue, inputName):
         """
         This method sets up a dict of either m5 or seeing values (or any other quantity

--- a/python/lsst/sims/utils/ObservationMetaData.py
+++ b/python/lsst/sims/utils/ObservationMetaData.py
@@ -71,12 +71,6 @@ class ObservationMetaData(object):
           Analogous to m5, corresponds to the seeing in arcseconds in the bandpasses in
           bandpassName
 
-        * epoch is the epoch of the RA, Dec system used to define
-          pointingRA/Dec.  This defaults to 2000.0 and should only be changed
-          if you plan to use this ObservationMetaData to query a database with meanRA,
-          Dec stored in a system that is not measured against the equinox at Julian
-          epoch 2000.0
-
         * rotSkyPos float
           The orientation of the telescope in degrees.
           This is used by the Astrometry mixins in sims_coordUtils.
@@ -101,14 +95,13 @@ class ObservationMetaData(object):
     def __init__(self, boundType=None, boundLength=None,
                  mjd=None, pointingRA=None, pointingDec=None, rotSkyPos=None,
                  bandpassName=None, site=Site(name='LSST'), m5=None, skyBrightness=None,
-                 seeing=None, epoch=2000.0):
+                 seeing=None):
 
         self._bounds = None
         self._boundType = boundType
         self._bandpass = bandpassName
         self._skyBrightness = skyBrightness
         self._site = site
-        self._epoch = epoch
         self._OpsimMetaData = None
 
         if mjd is not None:

--- a/python/lsst/sims/utils/Site.py
+++ b/python/lsst/sims/utils/Site.py
@@ -228,10 +228,8 @@ class Site (object):
     def __eq__(self, other):
 
         for param in self.__dict__:
-
             if param not in other.__dict__:
                 return False
-
             if self.__dict__[param] != other.__dict__[param]:
                 return False
 

--- a/python/lsst/sims/utils/Site.py
+++ b/python/lsst/sims/utils/Site.py
@@ -225,6 +225,25 @@ class Site (object):
             msg += "instantiate your Site with name='LSST'"
             warnings.warn(msg)
 
+    def __eq__(self, other):
+
+        for param in self.__dict__:
+
+            if param not in other.__dict__:
+                return False
+
+            if self.__dict__[param] != other.__dict__[param]:
+                return False
+
+        for param in other.__dict__:
+            if param not in self.__dict__:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @property
     def name(self):
         """

--- a/python/lsst/sims/utils/Site.py
+++ b/python/lsst/sims/utils/Site.py
@@ -110,8 +110,9 @@ class Site (object):
             temperature=11.5 centigrade
             pressure=750.0 millibars
             humidity=0.4
-            lapseRate=0.0065in Kelvin per meter
-            longitude: in degrees
+            lapseRate=0.0065 in Kelvin per meter
+
+        longitude: in degrees
 
         latitude: in degrees
 

--- a/python/lsst/sims/utils/SpatialBounds.py
+++ b/python/lsst/sims/utils/SpatialBounds.py
@@ -165,7 +165,7 @@ class CircleBounds(SpatialBounds):
 
         cosDec = np.cos(self.DEC)
 
-        if np.abs(cosDec)>1.0e-20:
+        if np.abs(cosDec) > 1.0e-20:
             RAmax = self.RAdeg + \
                 360.0 * np.arcsin(np.sin(0.5 * self.radius) /
                                   cosDec) / np.pi

--- a/python/lsst/sims/utils/SpatialBounds.py
+++ b/python/lsst/sims/utils/SpatialBounds.py
@@ -85,6 +85,23 @@ class SpatialBounds(with_metaclass(SpatialBoundsMetaClass, object)):
 
         raise NotImplementedError()
 
+    def __eq__(self, other):
+        for param in self.__dict__:
+            if param not in other.__dict__:
+                return False
+
+            if self.__dict__[param] != other.__dict__[param]:
+                return False
+
+        for param in other.__dict__:
+            if param not in self.__dict__:
+                return False
+
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     @classmethod
     def getSpatialBounds(self, name, *args, **kwargs):
         if name in self.SBregistry:

--- a/tests/testCleanUp.py
+++ b/tests/testCleanUp.py
@@ -1,0 +1,48 @@
+import unittest
+import lsst.utils.tests
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class CleanUpTestCase(unittest.TestCase):
+
+    def test_clean_up(self):
+        """
+        Test that sims_clean_up behaves as it should by importing a test module
+        with some dummy caches, adding things to them, and then deleting them.
+        """
+        from testModules.dummyModule import a_dict_cache
+        from testModules.dummyModule import a_list_cache
+        from lsst.sims.utils.CodeUtilities import sims_clean_up
+
+        self.assertEqual(len(sims_clean_up.targets), 2)
+
+        a_dict_cache['a'] = 1
+        a_dict_cache['b'] = 2
+        a_list_cache.append('alpha')
+        a_list_cache.append('beta')
+
+        self.assertEqual(len(a_dict_cache), 2)
+        self.assertEqual(len(a_list_cache), 2)
+
+        sims_clean_up()
+
+        self.assertEqual(len(a_dict_cache), 0)
+        self.assertEqual(len(a_list_cache), 0)
+        self.assertEqual(len(sims_clean_up.targets), 2)
+
+        # make sure that re-importing caches does not add second copies
+        # to sims_clean_up.targets
+        from testModules.dummyModule import a_list_cache
+
+        self.assertEqual(len(sims_clean_up.targets), 2)
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testModifiedJulianDate.py
+++ b/tests/testModifiedJulianDate.py
@@ -157,8 +157,12 @@ class MjdTest(unittest.TestCase):
         mjd1 = ModifiedJulianDate(TAI=43000.0)
         mjd2 = ModifiedJulianDate(TAI=43000.0)
         self.assertEqual(mjd1, mjd2)
+        self.assertTrue(mjd1 == mjd2)
+        self.assertFalse(mjd1 != mjd2)
         mjd3 = ModifiedJulianDate(TAI=43000.01)
         self.assertNotEqual(mjd1, mjd3)
+        self.assertFalse(mjd1 == mjd3)
+        self.assertTrue(mjd1 != mjd3)
 
     def test_deepcopy(self):
         # make sure that deepcopy() creates identical

--- a/tests/testModules/__init__.py
+++ b/tests/testModules/__init__.py
@@ -1,0 +1,1 @@
+# blank file

--- a/tests/testModules/dummyModule.py
+++ b/tests/testModules/dummyModule.py
@@ -1,0 +1,14 @@
+"""
+This is a dummy module that creates global caches so that we can test
+the behavior of sims_clean_up()
+"""
+from lsst.sims.utils.CodeUtilities import sims_clean_up
+
+__all__ = ["a_dict_cache", "a_list_cache"]
+
+a_dict_cache = {}
+
+a_list_cache = []
+
+sims_clean_up.targets.append(a_dict_cache)
+sims_clean_up.targets.append(a_list_cache)

--- a/tests/testObservationMetaData.py
+++ b/tests/testObservationMetaData.py
@@ -287,6 +287,177 @@ class ObservationMetaDataTest(unittest.TestCase):
 
         obs.OpsimMetaData = {'a': 1, 'b': 2}
 
+    def test_eq(self):
+        """
+        Test that we implemented __eq__ and __ne__ correctly
+        """
+        empty_obs = ObservationMetaData()
+        other_empty_obs = ObservationMetaData()
+        self.assertEqual(empty_obs, other_empty_obs)
+        self.assertTrue(empty_obs == other_empty_obs)
+        self.assertFalse(empty_obs != other_empty_obs)
+
+        dummy_site = Site(longitude=23.1, latitude=-11.1, temperature=11.0,
+                          height=8921.01, pressure=734.1, humidity=0.1,
+                          lapseRate=0.006)
+
+        ref_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                      mjd=59580.1, rotSkyPos=91.2,
+                                      bandpassName = 'u', m5=24.3,
+                                      skyBrightness=22.1, seeing=0.8,
+                                      site=dummy_site)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertEqual(ref_obs, other_obs)
+        self.assertTrue(ref_obs == other_obs)
+        self.assertFalse(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.41, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.2,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.2, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.1,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'g', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.1,
+                                        skyBrightness=22.1, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.2, seeing=0.8,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.81,
+                                        site=dummy_site)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs = ObservationMetaData(pointingRA=23.44, pointingDec=-19.1,
+                                        mjd=59580.1, rotSkyPos=91.2,
+                                        bandpassName = 'u', m5=24.3,
+                                        skyBrightness=22.1, seeing=0.8)
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        # use assignment to bring other_obs back into agreement with
+        # ref_obs
+        other_obs.site = dummy_site
+        self.assertEqual(ref_obs, other_obs)
+        self.assertTrue(ref_obs == other_obs)
+        self.assertFalse(ref_obs != other_obs)
+
+        # now try cases of m5, bandpass, and seeing being lists
+        ref_obs.setBandpassM5andSeeing(bandpassName=['u', 'r', 'z'],
+                                       m5=[22.1, 23.5, 24.2],
+                                       seeing=[0.6, 0.7, 0.8])
+
+        other_obs.setBandpassM5andSeeing(bandpassName=['u', 'r', 'z'],
+                                         m5=[22.1, 23.5, 24.2],
+                                         seeing=[0.6, 0.7, 0.8])
+
+        self.assertEqual(ref_obs, other_obs)
+        self.assertTrue(ref_obs == other_obs)
+        self.assertFalse(ref_obs != other_obs)
+
+        other_obs.setBandpassM5andSeeing(bandpassName=['u', 'i', 'z'],
+                                         m5=[22.1, 23.5, 24.2],
+                                         seeing=[0.6, 0.7, 0.8])
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs.setBandpassM5andSeeing(bandpassName=['u', 'r', 'z'],
+                                         m5=[22.1, 23.4, 24.2],
+                                         seeing=[0.6, 0.7, 0.8])
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs.setBandpassM5andSeeing(bandpassName=['u', 'r', 'z'],
+                                         m5=[22.1, 23.5, 24.2],
+                                         seeing=[0.2, 0.7, 0.8])
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
+        other_obs.setBandpassM5andSeeing(bandpassName=['u', 'z'],
+                                         m5=[22.1, 24.2],
+                                         seeing=[0.2, 0.8])
+
+        self.assertNotEqual(ref_obs, other_obs)
+        self.assertFalse(ref_obs == other_obs)
+        self.assertTrue(ref_obs != other_obs)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testSite.py
+++ b/tests/testSite.py
@@ -194,6 +194,103 @@ class SiteTest(unittest.TestCase):
         self.assertEqual(site.temperature, 20.0)
         self.assertEqual(site.temperature_kelvin, 293.15)
 
+    def test_eq(self):
+        """
+        Test that we have correctly implemented __eq__ in Site
+        """
+        reference_site = Site(name='ref', longitude=112.12,
+                              latitude=-83.121, temperature=112.1,
+                              height=3124.2, pressure=891.2,
+                              humidity=0.341, lapseRate=0.008)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertEqual(reference_site, other_site)
+        self.assertFalse(reference_site != other_site)
+        self.assertTrue(reference_site == other_site)
+
+        other_site = Site(name='other', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.13,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.122, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.2,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.3, pressure=891.2,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.3,
+                          humidity=0.341, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.342, lapseRate=0.008)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        other_site = Site(name='ref', longitude=112.12,
+                          latitude=-83.121, temperature=112.1,
+                          height=3124.2, pressure=891.2,
+                          humidity=0.341, lapseRate=0.009)
+
+        self.assertNotEqual(reference_site, other_site)
+        self.assertFalse(reference_site == other_site)
+        self.assertTrue(reference_site != other_site)
+
+        # test blank Sites
+        ref_site = Site()
+        other_site = Site()
+        self.assertEqual(ref_site, other_site)
+        self.assertTrue(ref_site == other_site)
+        self.assertFalse(ref_site != other_site)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/testSite.py
+++ b/tests/testSite.py
@@ -212,6 +212,28 @@ class SiteTest(unittest.TestCase):
         self.assertFalse(reference_site != other_site)
         self.assertTrue(reference_site == other_site)
 
+        # just in case we ever change the class to convert
+        # to radians only on demand, call for latitude/longitude
+        # in radians and then check that the two instances are
+        # still equal (since __eq__ just loops over the contents
+        # of self.__dict__, this could fail if other_site has not
+        # yet assigned a value to longitude/latitude_rad
+        reference_site.latitude_rad
+        self.assertEqual(reference_site, other_site)
+        self.assertFalse(reference_site != other_site)
+        self.assertTrue(reference_site == other_site)
+
+        reference_site.longitude_rad
+        self.assertEqual(reference_site, other_site)
+        self.assertFalse(reference_site != other_site)
+        self.assertTrue(reference_site == other_site)
+
+        reference_site.temperature_kelvin
+        self.assertEqual(reference_site, other_site)
+        self.assertFalse(reference_site != other_site)
+        self.assertTrue(reference_site == other_site)
+
+        # now test that __ne__ works correctly
         other_site = Site(name='other', longitude=112.12,
                           latitude=-83.121, temperature=112.1,
                           height=3124.2, pressure=891.2,

--- a/tests/testSpatialBounds.py
+++ b/tests/testSpatialBounds.py
@@ -118,6 +118,105 @@ class SpatialBoundsTest(unittest.TestCase):
         self.assertRaises(RuntimeError, SpatialBounds.getSpatialBounds,
                           'box', 1.0, 2.0, 'moreUtterNonsense')
 
+    def test_eq(self):
+        """
+        Test that we have implemented __eq__and __ne__ correctly
+        """
+        ref_circle = CircleBounds(113.1, -20.1, 1.56)
+        other_circle = CircleBounds(113.1, -20.1, 1.56)
+        self.assertEqual(ref_circle, other_circle)
+        self.assertTrue(ref_circle == other_circle)
+        self.assertFalse(ref_circle != other_circle)
+
+        other_circle = CircleBounds(113.2, -20.1, 1.56)
+        self.assertNotEqual(ref_circle, other_circle)
+        self.assertFalse(ref_circle == other_circle)
+        self.assertTrue(ref_circle != other_circle)
+
+        other_circle = CircleBounds(113.1, -20.2, 1.56)
+        self.assertNotEqual(ref_circle, other_circle)
+        self.assertFalse(ref_circle == other_circle)
+        self.assertTrue(ref_circle != other_circle)
+
+        other_circle = CircleBounds(113.1, -20.1, 1.57)
+        self.assertNotEqual(ref_circle, other_circle)
+        self.assertFalse(ref_circle == other_circle)
+        self.assertTrue(ref_circle != other_circle)
+
+        ref_square = BoxBounds(113.1, -20.1, 1.56)
+        self.assertNotEqual(ref_circle, ref_square)
+        self.assertFalse(ref_circle == ref_square)
+        self.assertTrue(ref_circle != ref_square)
+
+        other_square = BoxBounds(113.1, -20.1, 1.56)
+        self.assertEqual(ref_square, other_square)
+        self.assertTrue(ref_square == other_square)
+        self.assertFalse(ref_square != other_square)
+
+        other_square = BoxBounds(113.2, -20.1, 1.56)
+        self.assertNotEqual(ref_square, other_square)
+        self.assertFalse(ref_square == other_square)
+        self.assertTrue(ref_square != other_square)
+
+        other_square = BoxBounds(113.1, -20.2, 1.56)
+        self.assertNotEqual(ref_square, other_square)
+        self.assertFalse(ref_square == other_square)
+        self.assertTrue(ref_square != other_square)
+
+        other_square = BoxBounds(113.1, -20.1, 1.57)
+        self.assertNotEqual(ref_square, other_square)
+        self.assertFalse(ref_square == other_square)
+        self.assertTrue(ref_square != other_square)
+
+        ref_rect = BoxBounds(113.1, -20.1, [1.56, 1.56])
+        self.assertEqual(ref_rect, ref_square)
+        self.assertTrue(ref_rect == ref_square)
+        self.assertFalse(ref_rect != ref_square)
+
+        self.assertNotEqual(ref_rect, ref_circle)
+        self.assertFalse(ref_rect == ref_circle)
+        self.assertTrue(ref_rect != ref_circle)
+
+        ref_rect = BoxBounds(113.1, -20.1, [1.56, 1.52])
+        self.assertNotEqual(ref_rect, ref_square)
+        self.assertFalse(ref_rect == ref_square)
+        self.assertTrue(ref_rect != ref_square)
+
+        other_rect = BoxBounds(113.1, -20.1, [1.56, 1.52])
+        self.assertEqual(ref_rect, other_rect)
+        self.assertTrue(ref_rect == other_rect)
+        self.assertFalse(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.1, -20.1, np.array([1.56, 1.52]))
+        self.assertEqual(ref_rect, other_rect)
+        self.assertTrue(ref_rect == other_rect)
+        self.assertFalse(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.1, -20.1, (1.56, 1.52))
+        self.assertEqual(ref_rect, other_rect)
+        self.assertTrue(ref_rect == other_rect)
+        self.assertFalse(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.2, -20.1, (1.56, 1.52))
+        self.assertNotEqual(ref_rect, other_rect)
+        self.assertFalse(ref_rect == other_rect)
+        self.assertTrue(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.1, -20.2, (1.56, 1.52))
+        self.assertNotEqual(ref_rect, other_rect)
+        self.assertFalse(ref_rect == other_rect)
+        self.assertTrue(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.1, -20.1, (1.57, 1.52))
+        self.assertNotEqual(ref_rect, other_rect)
+        self.assertFalse(ref_rect == other_rect)
+        self.assertTrue(ref_rect != other_rect)
+
+        other_rect = BoxBounds(113.1, -20.1, (1.56, 1.51))
+        self.assertNotEqual(ref_rect, other_rect)
+        self.assertFalse(ref_rect == other_rect)
+        self.assertTrue(ref_rect != other_rect)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This is one of many (one for each sims_* repo...) PRs related to my effort to create a seamless integration between OpSim, CatSim, and PhoSim for generating full-focal plane image simulations.

This particular (sims_utils) pull request

1) Implements __eq__ and __ne__ methods for testing the equivalence of ObservationMetaData, ModifiedJulianDate, and Site objects

2) Creates a method sims_clean_up() for clearing out various data caches in the sims stack.  As I was writing this code, I started adding data caches for database connections and SEDs so that the stack did not unnecessarily open/read duplicates of these products.  Unfortunately, the presences of these caches caused the "is a file open" unit test to fail.  sims_clean_up() is meant to fix that problem.  Anywhere that a data cache is created, it is added to the list of targets associated with sims_clean_up().  Whenever sims_clean_up() is called, it calls `del` on the contents of its list of targets.  This prevents the dangling file handles from causing the unit test to fail.