### PR TITLE
Sim 2408/nfs bug

### DIFF
--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -9,9 +9,9 @@ def sims_clean_up():
     Any time a cache is added to the sims software stack, it can be added to
     the list sims_clean_up.targets.  When sims_clean_up() is called, it will
     loop through the contents of sims_clean_up.targets.  It will call pop()
-    on all of the contents of each sims_clean_up.target, and then reset each
-    sims_clean_up.target to either a blank dict or list (depending on what
-    the target was).
+    on all of the contents of each sims_clean_up.target, run close() on each
+    item it pops (if applicable), and then reset each sims_clean_up.target
+    to either a blank dict or list (depending on what the target was).
 
     Note: if a target cache is not a dict or a list, it will attempt to call
     close() on the cache.

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -39,6 +39,10 @@ def sims_clean_up():
                     except:
                         pass
 
+        else:
+            if hasattr(target, 'close'):
+                target.close()
+
     return None
 
 sims_clean_up.targets = []

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -13,9 +13,8 @@ def sims_clean_up():
     sims_clean_up.target to either a blank dict or list (depending on what
     the target was).
 
-    Note: this method assumes that all relevant caches are either dicts
-    or lists.  If it encounters another object, sims_clean_up() will do
-    nothing.
+    Note: if a target cache is not a dict or a list, it will attempt to call
+    close() on the cache.
     """
 
     if not hasattr(sims_clean_up, 'targets'):


### PR DESCRIPTION
Some unit tests in sims_catUtils were failing on NFS systems due to open database connections left dangling after the tests were run.  This pull request adds some modifications to `sims_clean_up()` in support of fixing that bug.