### PR TITLE
Sim 2437

### DIFF
--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -29,6 +29,7 @@ def sims_clean_up():
                         obj[1].close()
                     except:
                         pass
+                del obj
         elif isinstance(target, list):
             while len(target) > 0:
                 obj = target.pop()
@@ -37,10 +38,11 @@ def sims_clean_up():
                         obj.close()
                     except:
                         pass
-
+                del obj
         else:
             if hasattr(target, 'close'):
                 target.close()
+            del target
 
     return None
 

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -1,6 +1,7 @@
 from builtins import zip
 import numpy as np
 import numbers
+import gc
 
 
 def sims_clean_up():
@@ -44,6 +45,7 @@ def sims_clean_up():
                 target.close()
             del target
 
+    gc.collect()
     return None
 
 sims_clean_up.targets = []

--- a/python/lsst/sims/utils/CodeUtilities.py
+++ b/python/lsst/sims/utils/CodeUtilities.py
@@ -11,11 +11,13 @@ def sims_clean_up():
     the list sims_clean_up.targets.  When sims_clean_up() is called, it will
     loop through the contents of sims_clean_up.targets.  It will call pop()
     on all of the contents of each sims_clean_up.target, run close() on each
-    item it pops (if applicable), and then reset each sims_clean_up.target
-    to either a blank dict or list (depending on what the target was).
+    item it pops (if applicable), delete each item it pops, and then reset
+    each sims_clean_up.target to either a blank dict or list (depending on
+    what the target was).  sims_clean_up() will then run the garbage
+    collector.
 
     Note: if a target cache is not a dict or a list, it will attempt to call
-    close() on the cache.
+    close() on the cache and delete the cache.
     """
 
     if not hasattr(sims_clean_up, 'targets'):


### PR DESCRIPTION
Add `del` and `gc.collect()` calls to the `sims_clean_up()` method to prevent dangling resources from causing builds to fail on NFS-mounted machines.