### PR TITLE
Add TimeHandler to sims_utils

### DIFF
--- a/python/lsst/sims/utils/__init__.py
+++ b/python/lsst/sims/utils/__init__.py
@@ -14,3 +14,4 @@ from .stellarMags import *
 from .m5_flat_sed import *
 from .htmModule import *
 from .treeUtils import *
+from .timeHandler import *

--- a/python/lsst/sims/utils/timeHandler.py
+++ b/python/lsst/sims/utils/timeHandler.py
@@ -1,0 +1,247 @@
+from builtins import object
+from datetime import datetime
+from datetime import timedelta
+
+__all__ = ["TimeHandler"]
+
+
+class TimeHandler(object):
+    """Keep track of simulation time information.
+
+    This is a class tied to SOCS/Scheduler (OpSim).
+    Its properties will be reevaluated in the future and this
+    class may disappear.
+
+    Attributes
+    ----------
+    _unix_start : datetime.datetime
+        Holder for the start of the UNIX epoch
+    initial_dt : datetime.datetime
+        The date/time of the simulation start.
+    current_dt : datetime.datetime
+        The current simulation date/time.
+    """
+
+    def __init__(self, initial_date):
+        """Initialize the class.
+
+        Parameters
+        ----------
+            initial_date : str
+                The inital date in the format of YYYY-MM-DD.
+        """
+        self._unix_start = datetime(1970, 1, 1)
+        self.initial_dt = datetime.strptime(initial_date, "%Y-%m-%d")
+        self.current_dt = self.initial_dt
+
+    def _time_difference(self, datetime1, datetime2=None):
+        """Calculate the difference in seconds between two times.
+
+        This function calculates the difference in seconds between two given :class:`datetime` instances. If
+        datetime2 is None, it is assumed to be UNIX epoch start.
+
+        Parameters
+        ----------
+        datetime1 : datetime.datetime
+            The first datetime instance.
+        datetime2 : datetime.datetime
+            The second datetime instance.
+
+        Returns
+        -------
+        float
+            The difference in seconds between the two datetime instances.
+        """
+        if datetime2 is None:
+            datetime2 = self._unix_start
+        return (datetime1 - datetime2).total_seconds()
+
+    @property
+    def initial_timestamp(self):
+        """float: Return the UNIX timestamp for the initial date/time.
+        """
+        return self._time_difference(self.initial_dt)
+
+    @property
+    def current_timestamp(self):
+        """float: Return the UNIX timestamp for the current date/time.
+        """
+        return self._time_difference(self.current_dt)
+
+    @property
+    def current_midnight_timestamp(self):
+        """float: Return the UNIX timestamp of midnight for the current date.
+        """
+        midnight_dt = datetime(self.current_dt.year, self.current_dt.month, self.current_dt.day)
+        return self._time_difference(midnight_dt)
+
+    @property
+    def next_midnight_timestamp(self):
+        """float: Return the UNIX timestamp of midnight for the next day after current date.
+        """
+        midnight_dt = datetime(self.current_dt.year, self.current_dt.month, self.current_dt.day)
+        midnight_dt += timedelta(**{"days": 1})
+        return self._time_difference(midnight_dt)
+
+    @property
+    def time_since_start(self):
+        """float: The number of seconds since the start date.
+        """
+        return self._time_difference(self.current_dt, self.initial_dt)
+
+    def update_time(self, time_increment, time_units):
+        """Update the currently held timestamp.
+
+        This function updates the currently held time with the given increment and corresponding
+        units.
+
+        Parameters
+        ----------
+        time_increment : float
+            The increment to adjust the current time.
+        time_units : str
+            The time unit for the increment value.
+        """
+        time_delta_dict = {time_units: time_increment}
+        self.current_dt += timedelta(**time_delta_dict)
+
+    @property
+    def current_timestring(self):
+        """str: Return the ISO-8601 representation of the current date/time.
+        """
+        return self.current_dt.isoformat()
+
+    def has_time_elapsed(self, time_span):
+        """Return a boolean determining if the time span has elapsed.
+
+        This function looks to see if the time elapsed (current_time - initial_time) in units of
+        seconds is greater or less than the requested time span. It will return true if the time span
+        is greater than or equal the elapsed time and false if less than the elapsed time.
+
+        Parameters
+        ----------
+        time_span : float
+            The requested time span in seconds.
+
+        Returns
+        -------
+        bool
+            True if the time elapsed is greater or False if less than the time span.
+        """
+        return time_span >= self._time_difference(self.current_dt, self.initial_dt)
+
+    def future_datetime(self, time_increment, time_units, timestamp=None):
+        """Return a future datetime object.
+
+        This function adds the requested time increment to the current date/time to get a future date/time
+        and returns a datetime object. An alternative timestamp can be supplied and the time increment will
+        be applied to that instead. This function does not update the internal timestamp.
+
+        Parameters
+        ----------
+        time_increment : float
+            The increment to adjust the current time.
+        time_units : str
+            The time unit for the increment value.
+        timestamp : float, optional
+            An alternative timestamp to apply the time increment to.
+
+        Returns
+        -------
+        datetime.datetime
+            The datetime object for the future date/time.
+        """
+        if timestamp is not None:
+            dt = datetime.utcfromtimestamp(timestamp)
+        else:
+            dt = self.current_dt
+        time_delta_dict = {time_units: time_increment}
+        return dt + timedelta(**time_delta_dict)
+
+    def future_timestamp(self, time_increment, time_units, timestamp=None):
+        """Return the UNIX timestamp for the future date/time.
+
+        This function adds the requested time increment to the current date/time to get a future date/time
+        and returns the UNIX timestamp for that date/time. It does not update the internal timestamp.
+
+        Parameters
+        ----------
+        time_increment : float
+            The increment to adjust the current time.
+        time_units : str
+            The time unit for the increment value.
+        timestamp : float, optional
+            An alternative timestamp to apply the time increment to.
+
+        Returns
+        -------
+        float
+            The future UNIX timestamp.
+        """
+        return self._time_difference(self.future_datetime(time_increment, time_units, timestamp=timestamp))
+
+    def future_timestring(self, time_increment, time_units, timestamp=None):
+        """Return the ISO-8601 representation of the future date/time.
+
+        This function adds the requested time increment to the current date/time to get a future date/time
+        and returns the ISO-8601 formatted string for that date/time. It does not update the internal
+        timestamp.
+
+        Parameters
+        ----------
+        time_increment : float
+            The increment to adjust the current time.
+        time_units : str
+            The time unit for the increment value.
+        timestamp : float, optional
+            An alternative timestamp to apply the time increment to.
+
+        Returns
+        -------
+        str
+            The future date/time in ISO-8601.
+        """
+        return self.future_datetime(time_increment, time_units, timestamp=timestamp).isoformat()
+
+    def time_since_given(self, timestamp):
+        """Return the elapsed time (seconds).
+
+        This function takes the given timestamp and calculates the elapsed time in seconds
+        between it and the initial timestamp in the handler.
+
+        Parameters
+        ----------
+        timestamp : float
+            A UNIX timestamp
+
+        Returns
+        -------
+        float
+            The elapsed time (seconds) between the given
+        """
+        dt = datetime.utcfromtimestamp(timestamp)
+        return self._time_difference(dt, self.initial_dt)
+
+    def time_since_given_datetime(self, given_datetime, reverse=False):
+        """Return the elapsed time (seconds).
+
+        This function takes a given datetime object and calculates the elapsed time in seconds
+        between it and the initial timestamp in the handler. If the given datetime is prior to
+        the initial timestamp in the handler, use the reverse flag.
+
+        Parameters
+        ----------
+        given_datetime : datetime
+            The given timestamp.
+        reverse : bool, optional
+            Flag to make the difference in reverse. Default is False.
+
+        Returns
+        -------
+        float
+            The elapsed time (seconds) between the given timestamp and the initial timestamp
+        """
+        if reverse:
+            return self._time_difference(self.initial_dt, given_datetime)
+        else:
+            return self._time_difference(given_datetime, self.initial_dt)

--- a/tests/test_time_handler.py
+++ b/tests/test_time_handler.py
@@ -1,0 +1,115 @@
+from builtins import range
+from datetime import datetime
+import unittest
+import lsst.utils.tests
+from lsst.sims.utils import TimeHandler
+
+SECONDS_IN_DAY = 60.0 * 60.0 * 24.0
+
+
+class TimeHandlerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.start_date = "2020-05-24"
+        self.th = TimeHandler(self.start_date)
+
+    def test_basic_information_after_creation(self):
+        self.assertEqual(self.th.initial_dt, datetime(2020, 5, 24))
+
+    def test_bad_date_string(self):
+        with self.assertRaises(ValueError):
+            TimeHandler("18-09-15")
+
+    def test_return_initial_timestamp(self):
+        truth_timestamp = (datetime(2020, 5, 24) - datetime(1970, 1, 1)).total_seconds()
+        self.assertEqual(self.th.initial_timestamp, truth_timestamp)
+
+    def test_time_adjustment_seconds(self):
+        self.th.update_time(30.0, "seconds")
+        self.assertEqual(self.th.current_dt, datetime(2020, 5, 24, 0, 0, 30))
+
+    def test_time_adjustment_hours(self):
+        self.th.update_time(3.5, "hours")
+        self.assertEqual(self.th.current_dt, datetime(2020, 5, 24, 3, 30, 0))
+
+    def test_time_adjustment_days(self):
+        self.th.update_time(4, "days")
+        self.assertEqual(self.th.current_dt, datetime(2020, 5, 28))
+
+    def test_multiple_time_adjustments(self):
+        for i in range(3):
+            self.th.update_time(30.0, "seconds")
+        self.assertEqual(self.th.current_dt, datetime(2020, 5, 24, 0, 1, 30))
+
+    def test_timestamp_after_time_adjustment(self):
+        truth_timestamp = (datetime(2020, 5, 24, 0, 0, 30) - datetime(1970, 1, 1)).total_seconds()
+        self.th.update_time(30.0, "seconds")
+        self.assertEqual(self.th.current_timestamp, truth_timestamp)
+        self.assertNotEqual(self.th.current_timestamp, self.th.initial_timestamp)
+
+    def test_current_timestamp_string(self):
+        self.assertEqual(self.th.current_timestring, "2020-05-24T00:00:00")
+
+    def test_time_span_less_than_time_elapsed(self):
+        self.th.update_time(10, "days")
+        self.assertFalse(self.th.has_time_elapsed(9 * SECONDS_IN_DAY))
+
+    def test_time_span_is_greater_than_time_elapsed(self):
+        self.th.update_time(10, "days")
+        self.assertTrue(self.th.has_time_elapsed(11 * SECONDS_IN_DAY))
+
+    def test_future_timestring(self):
+        self.assertEqual(self.th.future_timestring(19.0, "hours"), "2020-05-24T19:00:00")
+
+    def test_midnight_timestamp(self):
+        self.th.update_time(15, "hours")
+        truth_timestamp = (datetime(2020, 5, 24) - datetime(1970, 1, 1)).total_seconds()
+        self.assertEqual(self.th.current_midnight_timestamp, truth_timestamp)
+
+    def test_next_midnight_timestamp(self):
+        self.th.update_time(15, "hours")
+        truth_timestamp = (datetime(2020, 5, 25) - datetime(1970, 1, 1)).total_seconds()
+        self.assertEqual(self.th.next_midnight_timestamp, truth_timestamp)
+
+    def test_future_timestamp(self):
+        truth_timestamp = 1590418800.0
+        self.assertEqual(self.th.future_timestamp(39, "hours"), truth_timestamp)
+
+    def test_future_datetime(self):
+        truth_datetime = datetime(2020, 5, 25, 15)
+        self.assertEqual(self.th.future_datetime(39, "hours"), truth_datetime)
+
+    def test_future_datetime_alternate_timestamp(self):
+        alternate_timestamp = 1590537600.0
+        truth_datetime = datetime(2020, 5, 28, 15)
+        self.assertEqual(self.th.future_datetime(39, "hours", timestamp=alternate_timestamp),
+                         truth_datetime)
+
+    def test_time_since_start(self):
+        self.th.update_time(10, "days")
+        self.assertEqual(self.th.time_since_start, 864000)
+
+    def test_time_since_given(self):
+        self.assertEqual(self.th.time_since_given(1590364800), 86400)
+
+    def test_time_since_given_datetime(self):
+        future_given_date = datetime(self.th.initial_dt.year, 6, 10)
+        self.assertEqual(self.th.time_since_given_datetime(future_given_date), 1468800)
+        past_given_date = datetime(self.th.initial_dt.year, 4, 20)
+        self.assertEqual(self.th.time_since_given_datetime(past_given_date, reverse=True), 2937600)
+        same_given_date = datetime(self.th.initial_dt.year, 5, 24)
+        self.assertEqual(self.th.time_since_given_datetime(same_given_date, reverse=True), 0)
+
+
+
+class TestMemory(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR would add TimeHandler to sims_utils. 
If there's a better place to move this, suggestions would be welcome. 

The problem right now is that we are moving the seeing model, cloud model, downtime, etc. out of sims_ocs and into their own packages. The seeing model (reading the seeing data) currently depends on a timeHandler object, to know what the offset into the seeing database ought to be for a given run (i.e. so you can start opsim at different times, but still end up at the right time during the "year" in the seeing_db). 

I would love to see the seeingModel, etc., code use ModifiedJulianDate instead at some point.
(the functionality I would need for sims_seeingModel is just to be able to get the seconds since a given day in the year for any time). 

