### PR TITLE
U/danielsf/outside/radius

### DIFF
--- a/python/lsst/sims/utils/ZernikeModule.py
+++ b/python/lsst/sims/utils/ZernikeModule.py
@@ -157,8 +157,8 @@ class ZernikePolynomialGenerator(object):
             log_r = np.where(np.isfinite(log_r), log_r, -1.0e10)
             r_power = np.exp(np.outer(log_r, self._powers[nm_tuple]))
 
-        results = np.dot(r_power, self._coeffs[nm_tuple])
-        return np.where(r<1.0, results, np.NaN)
+            results = np.dot(r_power, self._coeffs[nm_tuple])
+            return np.where(r<1.0, results, np.NaN)
 
     def _evaluate_radial(self, r, n, m):
         """

--- a/tests/testZernikeModule.py
+++ b/tests/testZernikeModule.py
@@ -6,7 +6,6 @@ import lsst.utils.tests
 
 from lsst.sims.utils import _FactorialGenerator
 from lsst.sims.utils import ZernikePolynomialGenerator
-from lsst.sims.utils import ZernikeRadialError
 
 
 def setup_module(module):
@@ -103,18 +102,22 @@ class ZernikeTestCase(unittest.TestCase):
         the Zernike polynomial with r>1
         """
         z_gen = ZernikePolynomialGenerator()
-        with self.assertRaises(ZernikeRadialError) as context:
-            z_gen.evaluate(1.2, 2.1, 2, 0)
-        with self.assertRaises(ZernikeRadialError) as context:
-            z_gen.evaluate(np.array([0.1, 0.5, 1.2]),
-                           np.array([0.1, 0.2, 0.3]),
-                           2, -2)
-        with self.assertRaises(ZernikeRadialError) as context:
-            z_gen.evaluate_xy(1.1, 1.2, 4, -2)
-        with self.assertRaises(ZernikeRadialError) as context:
-            z_gen.evaluate_xy(np.array([0.1, 0.2, 0.3]),
-                              np.array([0.1, 1.0, 0.1]),
-                              4, 2)
+        vv = z_gen.evaluate(1.2, 2.1, 2, 0)
+        self.assertTrue(np.isnan(vv))
+        vv = z_gen.evaluate(np.array([0.1, 0.5, 1.2]),
+                            np.array([0.1, 0.2, 0.3]),
+                            2, -2)
+        self.assertTrue(np.isnan(vv[2]))
+        self.assertFalse(np.isnan(vv[0]))
+        self.assertFalse(np.isnan(vv[1]))
+        vv = z_gen.evaluate_xy(1.1, 1.2, 4, -2)
+        self.assertTrue(np.isnan(vv))
+        vv = z_gen.evaluate_xy(np.array([0.1, 0.2, 0.3]),
+                               np.array([0.1, 1.0, 0.1]),
+                               4, 2)
+        self.assertTrue(np.isnan(vv[1]))
+        self.assertFalse(np.isnan(vv[0]))
+        self.assertFalse(np.isnan(vv[2]))
 
     def test_array(self):
         """


### PR DESCRIPTION
In responding to the PR for `u/danielsf/fix/focal/plane`, I set up a system where, if you asked for the focal plane coordinates of something well outside of the LSST focal plane, you got a `ZernikeRadialError`.  This would have caused a problem for us in image simulation, where we routinely ask for catalogs that are larger than the focal plane and let the image simulator figure out which objects are in and out of the focal plane.

This PR changes the behavior of `ZernikePolynomialGenerator` so that it will return `np.NaN` for any point that is outside of the LSST focal plane.  The routines in sims_coordUtils that find pixel positions and chip names will no how to deal with this.