### PR TITLE
U/lynnej/m5 flat sed spec

### DIFF
--- a/python/lsst/sims/utils/m5_flat_sed.py
+++ b/python/lsst/sims/utils/m5_flat_sed.py
@@ -94,7 +94,7 @@ def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, nexp=1, tauCloud=
         # This results in an error of about 0.01 mag in u band for 2x15s visits (< in other bands)
         # See https://github.com/lsst-pst/survey_strategy/blob/master/fbs_1.3/m5FlatSed%20update.ipynb
         # for a more in-depth evaluation.
-        baseExpTime = 30
+        m5_flat_sed.baseExpTime = 30.
         m5_flat_sed.Cm = {'u': 23.283,
                           'g': 24.493,
                           'r': 24.483,

--- a/python/lsst/sims/utils/m5_flat_sed.py
+++ b/python/lsst/sims/utils/m5_flat_sed.py
@@ -3,9 +3,43 @@ import numpy as np
 __all__ = ['m5_flat_sed', 'm5_scale']
 
 
-def m5_scale(expTime, nexp, musky, FWHMeff, airmass, darkSkyMag, Cm, dCm_infinity, kAtm,
+def m5_scale(expTime, nexp, airmass, FWHMeff, musky, darkSkyMag, Cm, dCm_infinity, kAtm,
              tauCloud=0, baseExpTime=15):
     """ Return m5 (scaled) value for all filters.
+
+    Parameters
+    ----------
+    expTime : float
+        Exposure time (in seconds) for each exposure
+    nexp : int
+        Number of exposures
+    airmass : float
+        Airmass of the observation
+    FWHMeff : np.ndarray or pd.DataFrame
+        FWHM (in arcseconds) per filter
+    musky : np.ndarray or pd.DataFrame
+        Sky background (in magnitudes/sq arcsecond) per filter of the observation
+    darkSkyMag : np.ndarray or pd.DataFrame
+        Dark Sky, zenith magnitude/sq arcsecond - to scale musky. per filter
+    Cm : np.ndarray or pd.DataFrame
+        Cm value for the throughputs per filter
+    dCm_infinity : np.ndarray or pd.DataFrame
+        dCm_infinity values for the throughputs, per filter
+    kAtm : np.ndarray or pd.DataFrame
+        Atmospheric extinction values, per filter
+    tauCloud : float, opt
+        Extinction due to clouds
+    baseExpTime : float, opt
+        The exposure time used to calculate Cm / dCm_infinity. Used to scale expTime.
+        This is the individual exposure exposure time.
+
+    Returns
+    -------
+    np.ndarray or pd.DataFrame
+        m5 values scaled for the visit conditions
+
+    Note: The columns required as input for m5_scale can be calculated using
+    the makeM5 function in lsst.syseng.throughputs.
     """
     # Calculate adjustment if readnoise is significant for exposure time
     # (see overview paper, equation 7)

--- a/python/lsst/sims/utils/m5_flat_sed.py
+++ b/python/lsst/sims/utils/m5_flat_sed.py
@@ -1,9 +1,27 @@
 import numpy as np
 
-__all__ = ['m5_flat_sed']
+__all__ = ['m5_flat_sed', 'm5_scale']
 
 
-def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, tauCloud=0):
+def m5_scale(expTime, nexp, musky, FWHMeff, airmass, darkSkyMag, Cm, dCm_infinity, kAtm,
+             tauCloud=0, baseExpTime=15):
+    """ Return m5 (scaled) value for all filters.
+    """
+    # Calculate adjustment if readnoise is significant for exposure time
+    # (see overview paper, equation 7)
+    Tscale = expTime / baseExpTime * np.power(10.0, -0.4 * (musky - darkSkyMag))
+    dCm = 0.
+    dCm += dCm_infinity
+    dCm -= 1.25 * np.log10(1 + (10**(0.8 * dCm_infinity) - 1)/Tscale)
+    # Calculate m5 for 1 exp - constants here come from definition of Cm/dCm_infinity
+    m5 = (Cm + dCm + 0.50 * (musky - 21.0) + 2.5 * np.log10(0.7 / FWHMeff) +
+          1.25 * np.log10(expTime / 30.0) - kAtm * (airmass - 1.0) - 1.1 * tauCloud)
+    if nexp > 1:
+        m5 = 1.25 * np.log10(nexp * 10**(0.8 * m5))
+    return m5
+
+
+def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, nexp=1, tauCloud=0):
     """Calculate the m5 value, using photometric scaling.  Note, does not include shape of the object SED.
 
     Parameters
@@ -15,9 +33,11 @@ def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, tauCloud=0):
     FWHMeff : float
         The seeing effective FWHM (arcsec)
     expTime : float
-        Exposure time for the entire visit in seconds
+        Exposure time for each exposure in the visit.
     airmass : float
         Airmass of the observation (unitless)
+    nexp : int, opt
+        The number of exposures. Default 1.  (total on-sky time = expTime * nexp)
     tauCloud : float (0.)
         Any extinction from clouds in magnitudes (positive values = more extinction)
 
@@ -32,17 +52,26 @@ def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, tauCloud=0):
     #
     # These values are calculated using $SYSENG_THROUGHPUTS/python/calcM5.py.
     # This set of values are calculated using v1.2 of the SYSENG_THROUGHPUTS repo.
+    # The exposure time scaling depends on knowing the value of the exposure time used to calculate Cm/etc.
 
     # Only define the dicts once on initial call
     if not hasattr(m5_flat_sed, 'Cm'):
-        m5_flat_sed.Cm = {'u': 23.067,
-                          'g': 24.414,
-                          'r': 24.439,
-                          'i': 24.325,
-                          'z': 24.157,
-                          'y': 23.730}
-        m5_flat_sed.dCm_infinity = {'u': 0.631,
-                                    'g': 0.179,
+        # Using Cm / dCm_infinity values calculated for a 1x15s visit.
+        # This results in an error of about 0.01 mag in u band for 2x15s visits (0.007 g, <0.005 other bands)
+        # but only at most 0.004 mag errors for 1x30s visits.
+        # In contrast, using the values from 2x15s visits results in negligible errors for 2x15s visits but
+        # 0.01 mag errors in u band for 1x30s visits (<0.003 in other bands).
+        # Similarly, using the values from 1x30s visits results in 0 errors for 1x30s visits but
+        # 0.015 mag errors in u band for 2x15s visits (<0.005 mag errors in other bands).
+        baseExpTime = 15
+        m5_flat_sed.Cm = {'u': 23.056,
+                          'g': 24.407,
+                          'r': 24.433,
+                          'i': 24.320,
+                          'z': 24.153,
+                          'y': 23.726}
+        m5_flat_sed.dCm_infinity = {'u': 0.622,
+                                    'g': 0.178,
                                     'r': 0.097,
                                     'i': 0.071,
                                     'z': 0.048,
@@ -61,12 +90,14 @@ def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, tauCloud=0):
                             'y': 18.612}
     # Calculate adjustment if readnoise is significant for exposure time
     # (see overview paper, equation 7)
-    Tscale = expTime / 30.0 * np.power(10.0, -0.4 * (musky - m5_flat_sed.msky[visitFilter]))
+    Tscale = expTime / m5_flat_sed.baseExpTime * np.power(10.0, -0.4 * (musky - m5_flat_sed.msky[visitFilter]))
     dCm = 0.
     dCm += m5_flat_sed.dCm_infinity[visitFilter]
-    dCm -= 1.25 * np.log10(1 + (10**(0.8 * m5_flat_sed.dCm_infinity[visitFilter]) - 1)/Tscale)
-    # Calculate fiducial m5
+    dCm -= 1.25 * np.log10(1 + (10**(0.8 * m5_flat_sed.dCm_infinity[visitFilter]) - 1) / Tscale)
+    # Calculate m5 for 1 exp - 30s and other constants here come from definition of Cm/dCm_infinity
     m5 = (m5_flat_sed.Cm[visitFilter] + dCm + 0.50 * (musky - 21.0) + 2.5 * np.log10(0.7 / FWHMeff) +
           1.25 * np.log10(expTime / 30.0) - m5_flat_sed.kAtm[visitFilter] * (airmass - 1.0) - 1.1 * tauCloud)
-
+    # Then combine with coadd if >1 exposure
+    if nexp > 1:
+        m5 = 1.25 * np.log10(nexp * 10**(0.8 * m5))
     return m5

--- a/python/lsst/sims/utils/m5_flat_sed.py
+++ b/python/lsst/sims/utils/m5_flat_sed.py
@@ -90,26 +90,23 @@ def m5_flat_sed(visitFilter, musky, FWHMeff, expTime, airmass, nexp=1, tauCloud=
 
     # Only define the dicts once on initial call
     if not hasattr(m5_flat_sed, 'Cm'):
-        # Using Cm / dCm_infinity values calculated for a 1x15s visit.
-        # This results in an error of about 0.01 mag in u band for 2x15s visits (0.007 g, <0.005 other bands)
-        # but only at most 0.004 mag errors for 1x30s visits.
-        # In contrast, using the values from 2x15s visits results in negligible errors for 2x15s visits but
-        # 0.01 mag errors in u band for 1x30s visits (<0.003 in other bands).
-        # Similarly, using the values from 1x30s visits results in 0 errors for 1x30s visits but
-        # 0.015 mag errors in u band for 2x15s visits (<0.005 mag errors in other bands).
-        baseExpTime = 15
-        m5_flat_sed.Cm = {'u': 23.056,
-                          'g': 24.407,
-                          'r': 24.433,
-                          'i': 24.320,
-                          'z': 24.153,
-                          'y': 23.726}
-        m5_flat_sed.dCm_infinity = {'u': 0.622,
-                                    'g': 0.178,
-                                    'r': 0.097,
-                                    'i': 0.071,
-                                    'z': 0.048,
-                                    'y': 0.037}
+        # Using Cm / dCm_infinity values calculated for a 1x30s visit.
+        # This results in an error of about 0.01 mag in u band for 2x15s visits (< in other bands)
+        # See https://github.com/lsst-pst/survey_strategy/blob/master/fbs_1.3/m5FlatSed%20update.ipynb
+        # for a more in-depth evaluation.
+        baseExpTime = 30
+        m5_flat_sed.Cm = {'u': 23.283,
+                          'g': 24.493,
+                          'r': 24.483,
+                          'i': 24.358,
+                          'z': 24.180,
+                          'y': 23.747}
+        m5_flat_sed.dCm_infinity = {'u': 0.414,
+                                    'g': 0.100,
+                                    'r': 0.052,
+                                    'i': 0.038,
+                                    'z': 0.026,
+                                    'y': 0.019}
         m5_flat_sed.kAtm = {'u': 0.492,
                             'g': 0.213,
                             'r': 0.126,


### PR DESCRIPTION
Updated Cm/dCm values and added "nexp" option for m5_flat_sed scaling.
Added additional m5_scale function to calculate m5 in all bands (return dataframe or numpy array with all values). 

The difference is that now the effect of two exposures in a visit is separated from a single exposure per visit - 1x30s visits no longer return the same m5 value as 2x15s visits. 
The exposure time should now be provided as the actual exposure time; visits with multiple exposures (2x15s) should provide exptime=15 and nexp=2. 
The API for m5_flat_sed should remain backwards compatible - for single exposure visits, no changes to the calling code need to be made. (for visits with >1 exposure, updates *should* be made to correct the exposure time and add nexp). 

See also https://github.com/lsst-pst/survey_strategy/blob/master/fbs_1.3/m5FlatSed%20update.ipynb containing analysis on the effect of the scaling and errors resulting from its use; scaling m5 does not result in quite the same value as a full SNR calculation would return. Typically these errors are <0.01 magnitude, which is likely higher than our actual uncertainty on what these values should be (given uncertainty on sky background, FWHM, QE and efficiency of the optics, effectiveness of source measurement, etc.).
