### PR TITLE
Replace is with == for string comparison

### DIFF
--- a/python/lsst/sims/utils/Site.py
+++ b/python/lsst/sims/utils/Site.py
@@ -129,7 +129,7 @@ class Site (object):
 
         default_params = None
         self._name = name
-        if self._name is 'LSST':
+        if self._name == 'LSST':
             default_params = LSST_site_parameters()
 
         if default_params is not None:


### PR DESCRIPTION
Using 'is' when comparing to a string raises a warning. Fix the comparison.